### PR TITLE
test: encode explicit invariants for `PrefixSearchResults` and `UserState`

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -9,23 +9,16 @@ name: verify
 on:
   push: # run this workflow on every push
   pull_request: # run this workflow on every pull_request
+  workflow_dispatch: # allow to manually trigger this workflow
 
 jobs:
-  verify-packages:
+  build-gobra:
     runs-on: ubuntu-latest
     container:
       image: gobraverifier/gobra-base:v6_z3_4.8.7
     env:
       GOBRA_REF: 8facab51220570ff88f72e71e794bcb336208e47
-      MOD_NAME: github.com/felixlinker/keytrans-verification
-      EXCLUDE_PKGS: "main"
-
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          path: keytrans-verification
-
       - name: Checkout Gobra
         uses: actions/checkout@v4
         with:
@@ -34,18 +27,104 @@ jobs:
           ref: ${{ env.GOBRA_REF }}
           submodules: 'recursive'
 
+      - name: Set sbt cache variables
+        # Cache path is relative to the directory in which sbt is invoked
+        run: echo "SBT_OPTS=-Dsbt.global.base=sbt-cache/.sbtboot -Dsbt.boot.directory=sbt-cache/.boot -Dsbt.ivy.home=sbt-cache/.ivy" >> $GITHUB_ENV
+      - name: Cache sbt
+        uses: actions/cache@v4
+        with:
+          path: |
+            sbt-cache/.sbtboot
+            sbt-cache/.boot
+            sbt-cache/.ivy/cache
+            gobra/project/target
+            gobra/target
+            gobra/viperserver/project/target
+            gobra/viperserver/target
+            gobra/viperserver/silicon/project/target
+            gobra/viperserver/silicon/target
+            gobra/viperserver/silicon/silver/project/target
+            gobra/viperserver/silicon/silver/target
+            gobra/viperserver/carbon/project/target
+            gobra/viperserver/carbon/target
+            gobra/viperserver/carbon/silver/project/target
+            gobra/viperserver/carbon/silver/target
+          key: ${{ runner.os }}-sbt-no-precompiled-sources-${{ hashFiles('**/build.sbt') }}
+
       - name: Assemble Gobra
         working-directory: gobra
         run: sbt assembly
+
+      - run: mv gobra/target/scala-2.13/gobra.jar gobra.jar
+
+      - name: Upload gobra.jar
+        uses: actions/upload-artifact@v4
+        with:
+          name: gobra.jar
+          path: gobra.jar
+          retention-days: 2
+
+
+  type-check-packages:
+    runs-on: ubuntu-latest
+    needs: build-gobra
+    container:
+      image: gobraverifier/gobra-base:v6_z3_4.8.7
+    env:
+      MOD_NAME: github.com/felixlinker/keytrans-verification
+      EXCLUDE_PKGS: "main"
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          path: keytrans-verification
+
+      - name: Download gobra.jar
+        uses: actions/download-artifact@v4
+        with:
+          name: gobra.jar
 
       - name: Create stats dir
         working-directory: keytrans-verification
         run: mkdir .gobra
 
-      - name: Verify files
+      - name: Type-check packages
         working-directory: keytrans-verification
         run: |
-          java -jar -Xss128m ../gobra/target/scala-2.13/gobra.jar \
+          java -jar -Xss128m ../gobra.jar \
+            --module ${{ env.MOD_NAME }} \
+            --recursive \
+            --include "." ".verification" \
+            --noVerify
+
+
+  verify-packages:
+    runs-on: ubuntu-latest
+    needs: build-gobra
+    container:
+      image: gobraverifier/gobra-base:v6_z3_4.8.7
+    env:
+      MOD_NAME: github.com/felixlinker/keytrans-verification
+      EXCLUDE_PKGS: "main"
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          path: keytrans-verification
+
+      - name: Download gobra.jar
+        uses: actions/download-artifact@v4
+        with:
+          name: gobra.jar
+
+      - name: Create stats dir
+        working-directory: keytrans-verification
+        run: mkdir .gobra
+
+      - name: Verify packages
+        working-directory: keytrans-verification
+        run: |
+          java -jar -Xss128m ../gobra.jar \
             --module ${{ env.MOD_NAME }} \
             --hyperMode extended \
             --recursive \

--- a/.verification/crypto/sha256/sha256.gobra
+++ b/.verification/crypto/sha256/sha256.gobra
@@ -1,3 +1,9 @@
 package sha256
 
+const BlockSize = 64
 const Size = 32
+const Size224 = 28
+
+requires noPerm < p
+preserves acc(data, p)
+func Sum256(data []byte, ghost p perm) [Size]byte

--- a/.verification/fmt/fmt.gobra
+++ b/.verification/fmt/fmt.gobra
@@ -1,0 +1,4 @@
+package fmt
+
+func Print(s string)
+func Println(s string)

--- a/.verification/slices/slices.gobra
+++ b/.verification/slices/slices.gobra
@@ -1,0 +1,1 @@
+package slices

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,5 +4,6 @@
     "gobraSettings.includeDirs": [
         ".",
         ".verification"
-    ]
+    ],
+    "gobraSettings.autoVerify": false
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,8 +4,5 @@
     "gobraSettings.includeDirs": [
         ".",
         ".verification"
-    ],
-    "[go]": {
-        "editor.formatOnSave": false,
-    }
+    ]
 }

--- a/pkg/client/treeview.go
+++ b/pkg/client/treeview.go
@@ -169,39 +169,24 @@ pred (s *UserState) Inv() {
 
 //@ requires noPerm < p
 //@ preserves acc(timestamps, p)
-//@ ensures res ==> forall i, j int :: 0 <= i && i < j && j < len(timestamps) ==> timestamps[i] < timestamps[j]
+//@ ensures res ==> forall i, j int :: { timestamps[i], timestamps[j] } 0 <= i && i < j && j < len(timestamps) ==> timestamps[i] <= timestamps[j]
 func checkIncreasing(timestamps []uint64 /*@, ghost p perm @*/) (res bool) {
-	// The following if statement is not necessary and, also,
-	// triggers bug #898 (see https://github.com/viperproject/gobra/issues/898)
-	/*
-		if len(timestamps) == 0 {
-			return true
-		}
-	*/
+	if len(timestamps) == 0 {
+		return true
+	}
 
-	/* the following checks are insufficient:
 	tmp := timestamps[0]
-	for _, v := range timestamps[1:] {
+
+	//@ invariant 0 <= k && k <= len(timestamps)
+	//@ invariant acc(timestamps, p)
+	//@ invariant forall i int :: { timestamps[i] } 0 <= i && i < k ==> timestamps[i] <= tmp
+	//@ invariant forall i, j int :: { timestamps[i], timestamps[j] } 0 <= i && i < j && j < k ==> timestamps[i] <= timestamps[j]
+	for k := 0; k < len(timestamps); k++ {
+		v := timestamps[k]
 		if tmp > v {
 			return false
 		}
 		tmp = v
-	}
-	*/
-
-	//@ invariant 0 <= k && k <= len(timestamps)
-	//@ invariant acc(timestamps, p)
-	//@ invariant forall i, j int :: 0 <= i && i < k && i < j && j < len(timestamps) ==> timestamps[i] < timestamps[j]
-	for k := 0; k < len(timestamps); k++ {
-		//@ invariant k + 1 <= l && l <= len(timestamps)
-		//@ invariant acc(timestamps, p)
-		//@ invariant forall i, j int :: 0 <= i && i < k && i < j && j < len(timestamps) ==> timestamps[i] < timestamps[j]
-		//@ invariant forall j int :: k < j && j < l ==> timestamps[k] < timestamps[j]
-		for l := k + 1; l < len(timestamps); l++ {
-			if timestamps[k] >= timestamps[l] {
-				return false
-			}
-		}
 	}
 
 	return true

--- a/pkg/client/treeview.go
+++ b/pkg/client/treeview.go
@@ -217,7 +217,7 @@ func (st *UserState) UpdateView(new_head FullTreeHead, prf proofs.CombinedTreePr
 	oldFrontier := oldSearchTree.FrontierNodes( /*@ 1/2 @*/ )
 	newFrontier := newSearchTree.FrontierNodes( /*@ 1/2 @*/ )
 	if st.Size == 0 {
-		st.Frontier_timestamps = newFrontier
+		st.Frontier_timestamps = prf.Timestamps
 	} else if pathToOldHead, err := newSearchTree.PathTo(st.Size - 1 /*@, 1/2 @*/); err != nil {
 		//@ fold st.Inv()
 		//@ fold acc(prf.Inv(), p)
@@ -237,6 +237,11 @@ func (st *UserState) UpdateView(new_head FullTreeHead, prf proofs.CombinedTreePr
 		st.Frontier_timestamps = append( /*@ perm(p/2), @*/ st.Frontier_timestamps[:i], prf.Timestamps[i:]...)
 	}
 	//@ fold acc(prf.Inv(), p)
+
+	if len(newFrontier) != len(st.Frontier_timestamps) {
+		//@ fold st.Inv()
+		return errors.New("incorrect number of timestamps provided")
+	}
 
 	st.Size = new_head.Tree_head.Tree_size
 	//@ fold st.Inv()

--- a/pkg/client/treeview.go
+++ b/pkg/client/treeview.go
@@ -163,7 +163,8 @@ pred (s *UserState) Inv() {
 	acc(s) &&
 	acc(s.Full_subtrees) &&
 	// NodeValue is a fixed-size array and, thus, does not require further permissions
-	acc(s.Frontier_timestamps)
+	acc(s.Frontier_timestamps) &&
+	(s.Size == 0 ==> len(s.Full_subtrees) == 0)
 }
 @*/
 

--- a/pkg/crypto/vrf.go
+++ b/pkg/crypto/vrf.go
@@ -14,7 +14,7 @@ type VrfInput struct {
 
 /*@
 pred (input VrfInput) Inv() {
-	acc(input.label) && len(input.label) <= 255
+	acc(input.Label) && len(input.Label) <= 255
 }
 @*/
 

--- a/pkg/proofs/ladder.go
+++ b/pkg/proofs/ladder.go
@@ -3,17 +3,17 @@ package proofs
 func FullBinaryLadderSteps(target uint32) (r []uint32) {
 	r = make([]uint32, 0)
 	var i uint32 = 1
-	for i - 1 < target {
-		r = append(r, i - 1)
+	for i-1 < target {
+		r = append( /*@ perm(1/2), @*/ r, i-1)
 		i = i << 1
 	}
-	// i is now the smallest power of two minus one larger than or equal to target
-	x_in := r[len(r) - 1]
+	// i is now the smallest power of two larger than or equal to target
+	x_in := r[len(r)-1]
 	x_out := i
-	r = append(r, i - 1) // this will be the first proof of non-inclusion
+	r = append( /*@ perm(1/2), @*/ r, i-1) // this will be the first proof of non-inclusion
 	for i > 1 {
 		i := x_in + ((x_out - x_in) / 2)
-		r = append(r, i - 1)
+		r = append( /*@ perm(1/2), @*/ r, i-1)
 		if i <= target {
 			x_in = i
 		} else {

--- a/pkg/proofs/ladder.go
+++ b/pkg/proofs/ladder.go
@@ -3,21 +3,23 @@ package proofs
 func FullBinaryLadderSteps(target uint32) (r []uint32) {
 	r = make([]uint32, 0)
 	var i uint32 = 1
-	for i-1 < target {
+	for i-1 <= target {
 		r = append( /*@ perm(1/2), @*/ r, i-1)
 		i = i << 1
 	}
-	// i is now the smallest power of two larger than or equal to target
+	// i is now the smallest power of two s.t. i-1 is larger than target
+
 	x_in := r[len(r)-1]
-	x_out := i
-	r = append( /*@ perm(1/2), @*/ r, i-1) // this will be the first proof of non-inclusion
-	for i > 1 {
-		i := x_in + ((x_out - x_in) / 2)
-		r = append( /*@ perm(1/2), @*/ r, i-1)
+	x_out := i - 1
+	r = append( /*@ perm(1/2), @*/ r, x_out) // this will be the first proof of non-inclusion
+
+	for ((x_out - x_in) / 2) > 0 {
+		next := x_in + ((x_out - x_in) / 2) - 1
+		r = append( /*@ perm(1/2), @*/ r, next)
 		if i <= target {
-			x_in = i
+			x_in = next
 		} else {
-			x_out = i
+			x_out = next
 		}
 	}
 	return r

--- a/pkg/proofs/ladder.go
+++ b/pkg/proofs/ladder.go
@@ -2,18 +2,18 @@ package proofs
 
 func FullBinaryLadderSteps(target uint32) (r []uint32) {
 	r = make([]uint32, 0)
-	var i uint32 = 0
-	for i < target {
-		r = append(r, i)
+	var i uint32 = 1
+	for i - 1 < target {
+		r = append(r, i - 1)
 		i = i << 1
 	}
-	// i is now the smallest power of two larger than or equal to target
+	// i is now the smallest power of two minus one larger than or equal to target
 	x_in := r[len(r) - 1]
 	x_out := i
-	r = append(r, i) // this will be the first proof of non-inclusion
+	r = append(r, i - 1) // this will be the first proof of non-inclusion
 	for i > 1 {
 		i := x_in + ((x_out - x_in) / 2)
-		r = append(r, i)
+		r = append(r, i - 1)
 		if i <= target {
 			x_in = i
 		} else {

--- a/pkg/proofs/prefixproof.go
+++ b/pkg/proofs/prefixproof.go
@@ -21,14 +21,14 @@ pred (t PrefixTree) Inv() {
 // Recursive prefix tree data structure
 type PrefixTree struct {
 	// Hash value of this node; must be computed if nil
-	Value   *[sha256.Size]byte
+	Value *[sha256.Size]byte
 	// If set, this node is a leaf of the given value. Left and Right must be nil
 	// in this case.
-	Leaf    *PrefixLeaf
+	Leaf *PrefixLeaf
 	// Left subtree. May be nil even if Right is not nil.
-	Left    *PrefixTree
+	Left *PrefixTree
 	// Right subtree. May be nil even if Left is not nil.
-	Right   *PrefixTree
+	Right *PrefixTree
 }
 
 // Get the left or right child of the given tree and initialize if necessary
@@ -55,7 +55,7 @@ func (tree *PrefixTree) initializeAt(vrf_output [32]byte, depth uint8, sub_tree 
 	node := tree
 	var i uint8
 	for i = 0; i < depth; i++ {
-		node = tree.getChild(vrf_output[i / 8] >> (i % 8) != 0)
+		node = tree.getChild(vrf_output[i/8]>>(i%8) != 0)
 	}
 
 	if sub_tree.Value != nil {
@@ -76,7 +76,7 @@ func (tree *PrefixTree) initializeAt(vrf_output [32]byte, depth uint8, sub_tree 
 // steps. We assume that the binary ladder steps are in the order that the
 // binary ladder would request them.
 func (prf PrefixProof) ToTree(fullLadder []BinaryLadderStep) (tree *PrefixTree, err error) {
-	tree = &PrefixTree{ nil, nil, nil, nil }
+	tree = &PrefixTree{nil, nil, nil, nil}
 	if len(fullLadder) < len(prf.Results) {
 		return nil, errors.New("too many results")
 	}
@@ -86,7 +86,8 @@ func (prf PrefixProof) ToTree(fullLadder []BinaryLadderStep) (tree *PrefixTree, 
 		return nil, err
 	}
 
-	for i, step := range(steps) {
+	for i := 0; i < len(steps); i++ {
+		step := steps[i]
 		r := prf.Results[i]
 		if r.Result_type == NonInclusionLeaf {
 			if step.Result.Leaf == nil {
@@ -97,14 +98,14 @@ func (prf PrefixProof) ToTree(fullLadder []BinaryLadderStep) (tree *PrefixTree, 
 				})
 			}
 		} else {
-			leaf := PrefixLeaf{
+			leaf /*@ @ @*/ := PrefixLeaf{
 				Vrf_output: crypto.VRF_proof_to_hash(step.Step.Proof),
 				Commitment: step.Step.Commitment,
 			}
 			if r.Result_type == Inclusion {
-				tree.initializeAt(leaf.Vrf_output, r.Depth, PrefixTree{ Leaf: &leaf })
+				tree.initializeAt(leaf.Vrf_output, r.Depth, PrefixTree{Leaf: &leaf})
 			} else if r.Result_type == NonInclusionParent {
-				tree.initializeAt(leaf.Vrf_output, r.Depth, PrefixTree{ Value: &[32]byte{} })
+				tree.initializeAt(leaf.Vrf_output, r.Depth, PrefixTree{Value: &[32]byte{}})
 			} else {
 				return nil, errors.New("illegal result type")
 			}
@@ -161,14 +162,14 @@ func (tree *PrefixTree) SetMissingSubtrees(ordered_values []NodeValue) ([]NodeVa
 }
 
 func (tree *PrefixTree) HashContent() (hashContent []byte, err error) {
-	hashContent = make([]byte, sha256.Size + 1)
+	hashContent = make([]byte, sha256.Size+1)
 	if tree == nil {
 		return hashContent, nil
 	} else if tree.Left == nil && tree.Right == nil {
-		if value, err := tree.ComputeHash(); err != nil {
+		if value /*@ @ @*/, err := tree.ComputeHash(); err != nil {
 			return nil, err
 		} else {
-			return append([]byte{ 0x01 }, value[:]...), nil
+			return append( /*@ perm(1/2), @*/ []byte{0x01}, value[:]...), nil
 		}
 	} else {
 		if leftContent, err := tree.Left.HashContent(); err != nil {
@@ -176,8 +177,8 @@ func (tree *PrefixTree) HashContent() (hashContent []byte, err error) {
 		} else if rightContent, err := tree.Right.HashContent(); err != nil {
 			return nil, err
 		} else {
-			hashContent = append([]byte{ 0x02 }, leftContent...)
-			return append(hashContent, rightContent...), nil
+			hashContent = append( /*@ perm(1/2), @*/ []byte{0x02}, leftContent...)
+			return append( /*@ perm(1/2), @*/ hashContent, rightContent...), nil
 		}
 	}
 }
@@ -195,7 +196,7 @@ func (tree *PrefixTree) ComputeHash() (hash [sha256.Size]byte, err error) {
 			// TODO: We would have to include length, too, to be compliant with TLS
 			// encoding, but not so important right now because inputs are
 			// fixed-length and this may get changed in the future
-			value := sha256.Sum256(append(tree.Leaf.Vrf_output[:], tree.Leaf.Commitment[:]...))
+			value /*@ @ @*/ := sha256.Sum256(append( /*@ perm(1/2), @*/ tree.Leaf.Vrf_output[:], tree.Leaf.Commitment[:]...) /*@, perm(1/2) @*/)
 			tree.Value = &value
 			return value, nil
 		}
@@ -205,7 +206,7 @@ func (tree *PrefixTree) ComputeHash() (hash [sha256.Size]byte, err error) {
 		} else if rightContent, err := tree.Right.HashContent(); err != nil {
 			return [sha256.Size]byte{}, err
 		} else {
-			value := sha256.Sum256(append(leftContent, rightContent...))
+			value /*@ @ @*/ := sha256.Sum256(append( /*@ perm(1/2), @*/ leftContent, rightContent...) /*@, perm(1/2) @*/)
 			tree.Value = &value
 			return value, nil
 		}

--- a/pkg/proofs/proofs.go
+++ b/pkg/proofs/proofs.go
@@ -56,11 +56,23 @@ type PrefixLeaf struct {
 	Commitment [sha256.Size]byte
 }
 
+/*@
+pred (p *PrefixLeaf) Inv() {
+     acc(p)
+}
+@*/
+
 type PrefixSearchResult struct {
 	Result_type int
 	Leaf        *PrefixLeaf // only present when result_type == NonInclusionLeaf
 	Depth       uint8
 }
+
+/*@
+pred (p PrefixSearchResults) Inv() {
+	p.Result_type == NonInclusionLeaf ==> p.Leaf.Inv()
+}
+@*/
 
 type PrefixProof struct {
 	Results  []PrefixSearchResult

--- a/pkg/proofs/proofs.go
+++ b/pkg/proofs/proofs.go
@@ -82,10 +82,11 @@ pred (c CombinedTreeProof) Inv() {
 @*/
 
 type CompleteBinaryLadderStep struct {
-	Step BinaryLadderStep
+	Step   BinaryLadderStep
 	Result PrefixSearchResult
 }
 
+//@ trusted
 func CombineResults(results []PrefixSearchResult, steps []BinaryLadderStep) (completeSteps []CompleteBinaryLadderStep, err error) {
 	completeSteps = make([]CompleteBinaryLadderStep, 0, len(results))
 	if len(steps) < len(results) {
@@ -94,18 +95,25 @@ func CombineResults(results []PrefixSearchResult, steps []BinaryLadderStep) (com
 
 	sortedSteps := make([]BinaryLadderStep, 0, len(results))
 	copy(sortedSteps, steps[:len(results)])
-	slices.SortFunc(sortedSteps, func(a, b BinaryLadderStep) int {
-		hashA := crypto.VRF_proof_to_hash(a.Proof)
-		hashB := crypto.VRF_proof_to_hash(b.Proof)
-		return bytes.Compare(hashA[:], hashB[:])
-	})
+	sortBinaryLadderSteps(sortedSteps)
 
-	for i, step := range(sortedSteps) {
+	for i, step := range sortedSteps {
 		completeSteps = append(completeSteps, CompleteBinaryLadderStep{
-			Step: step,
+			Step:   step,
 			Result: results[i],
 		})
 	}
 
 	return completeSteps, nil
+}
+
+//@ trusted
+//@ preserves acc(sortedSteps)
+func sortBinaryLadderSteps(sortedSteps []BinaryLadderStep) {
+	slices.SortFunc(sortedSteps, func(a, b BinaryLadderStep) int {
+		hashA := crypto.VRF_proof_to_hash(a.Proof)
+		hashB := crypto.VRF_proof_to_hash(b.Proof)
+		return bytes.Compare(hashA[:], hashB[:])
+	})
+	return
 }


### PR DESCRIPTION
Turns implicit invariants (in comments on the Go structs) into explicit invariants (in Gobra predicates).