### PR TITLE
test: encode explicit invariants for PrefixSearchResults and UserState

### DIFF
--- a/pkg/client/treeview.go
+++ b/pkg/client/treeview.go
@@ -163,7 +163,8 @@ pred (s *UserState) Inv() {
 	acc(s) &&
 	acc(s.Full_subtrees) &&
 	// NodeValue is a fixed-size array and, thus, does not require further permissions
-	acc(s.Frontier_timestamps)
+	acc(s.Frontier_timestamps) &&
+	(s.Size == 0 ==> len(s.Full_subtrees) == 0)
 }
 @*/
 

--- a/pkg/proofs/proofs.go
+++ b/pkg/proofs/proofs.go
@@ -56,11 +56,23 @@ type PrefixLeaf struct {
 	Commitment [sha256.Size]byte
 }
 
+/*@
+pred (p *PrefixLeaf) Inv() {
+     acc(p)
+}
+@*/
+
 type PrefixSearchResult struct {
 	Result_type int
 	Leaf        *PrefixLeaf // only present when result_type == NonInclusionLeaf
 	Depth       uint8
 }
+
+/*@
+pred (p PrefixSearchResults) Inv() {
+	p.Result_type == NonInclusionLeaf ==> p.Leaf.Inv()
+}
+@*/
 
 type PrefixProof struct {
 	Results  []PrefixSearchResult

--- a/pkg/proofs/proofs.go
+++ b/pkg/proofs/proofs.go
@@ -69,7 +69,7 @@ type PrefixSearchResult struct {
 }
 
 /*@
-pred (p PrefixSearchResults) Inv() {
+pred (p PrefixSearchResult) Inv() {
 	p.Result_type == NonInclusionLeaf ==> p.Leaf.Inv()
 }
 @*/


### PR DESCRIPTION
Turns implicit invariants (in comments on the Go structs) into explicit invariants (in Gobra predicates).

Supersedes #4 now that `main` has superseded `implementation`.