### PR TITLE
Update to latest `hyperGobra` branch

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -17,7 +17,7 @@ jobs:
     container:
       image: gobraverifier/gobra-base:v6_z3_4.8.7
     env:
-      GOBRA_REF: 8facab51220570ff88f72e71e794bcb336208e47
+      GOBRA_REF: 151a1852991acd9966db402b9e4819b1bbe9b1c0
     steps:
       - name: Checkout Gobra
         uses: actions/checkout@v4
@@ -93,6 +93,7 @@ jobs:
         run: |
           java -jar -Xss128m ../gobra.jar \
             --module ${{ env.MOD_NAME }} \
+             --hyperMode extended \
             --recursive \
             --include "." ".verification" \
             --noVerify

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -122,16 +122,6 @@ jobs:
         working-directory: keytrans-verification
         run: mkdir .gobra
 
-      - name: Verify packages (with hyperMode)
-        working-directory: keytrans-verification
-        run: |
-          java -jar -Xss128m ../gobra.jar \
-            --module ${{ env.MOD_NAME }} \
-            --hyperMode extended \
-            --recursive \
-            --include "." ".verification" \
-            --excludePackages ${{ env.EXCLUDE_PKGS }} "client"
-
       - name: Verify packages (without hyperMode)
         working-directory: keytrans-verification
         run: |
@@ -141,6 +131,16 @@ jobs:
             --recursive \
             --include "." ".verification" \
             --includePackages "client"
+
+      - name: Verify packages (with hyperMode)
+        working-directory: keytrans-verification
+        run: |
+          java -jar -Xss128m ../gobra.jar \
+            --module ${{ env.MOD_NAME }} \
+            --hyperMode extended \
+            --recursive \
+            --include "." ".verification" \
+            --excludePackages ${{ env.EXCLUDE_PKGS }} "client"
 
       - name: Upload Gobra statistics
         if: ${{ always() }}

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -17,7 +17,7 @@ jobs:
     container:
       image: gobraverifier/gobra-base:v6_z3_4.8.7
     env:
-      GOBRA_REF: 151a1852991acd9966db402b9e4819b1bbe9b1c0
+      GOBRA_REF: 31c7f4ad2696dfbd22953f4031d04b0a3d6f5a44
     steps:
       - name: Checkout Gobra
         uses: actions/checkout@v4
@@ -93,7 +93,7 @@ jobs:
         run: |
           java -jar -Xss128m ../gobra.jar \
             --module ${{ env.MOD_NAME }} \
-             --hyperMode extended \
+            --hyperMode extended \
             --recursive \
             --include "." ".verification" \
             --noVerify
@@ -122,7 +122,7 @@ jobs:
         working-directory: keytrans-verification
         run: mkdir .gobra
 
-      - name: Verify packages
+      - name: Verify packages (with hyperMode)
         working-directory: keytrans-verification
         run: |
           java -jar -Xss128m ../gobra.jar \
@@ -130,7 +130,17 @@ jobs:
             --hyperMode extended \
             --recursive \
             --include "." ".verification" \
-            --excludePackages ${{ env.EXCLUDE_PKGS }}
+            --excludePackages ${{ env.EXCLUDE_PKGS }} "client"
+
+      - name: Verify packages (without hyperMode)
+        working-directory: keytrans-verification
+        run: |
+          java -jar -Xss128m ../gobra.jar \
+            --module ${{ env.MOD_NAME }} \
+            --hyperMode off \
+            --recursive \
+            --include "." ".verification" \
+            --includePackages "client"
 
       - name: Upload Gobra statistics
         if: ${{ always() }}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,8 @@
 {
-    "gobraSettings.buildVersion": "Nightly"
+    "gobraSettings.buildVersion": "Nightly",
+    "gobraSettings.moduleName": "github.com/felixlinker/keytrans-verification",
+    "gobraSettings.includeDirs": [
+        ".",
+        ".verification"
+    ]
 }

--- a/commitment/commitment.go
+++ b/commitment/commitment.go
@@ -3,19 +3,19 @@ package commitment
 // @ requires low(hash)
 // @ ensures  res ==> low(value)
 func verify(hash int, value int) (res bool) {
-    res = (hash == computeHash(value))
-    return
+	res = (hash == computeHash(value))
+	return
 }
 
 // @ requires low(hash)
 // @ ensures  res ==> low(value)
 func verifyWithBranching(hash int, value int) (res bool) {
-    // the following if statement fails because the condition is not-low
-    // however, this limitation could be lifted by a more complicated encoding
-    if hash != computeHash(value) {
-        return false
-    }
-    return true
+	// the following if statement fails because the condition is not-low
+	// however, this limitation could be lifted by a more complicated encoding
+	if hash != computeHash(value) {
+		return false
+	}
+	return true
 }
 
 // the following postcondition specifies that the Go function `computeHash` behaves like the
@@ -24,7 +24,7 @@ func verifyWithBranching(hash int, value int) (res bool) {
 func computeHash(input int) (res int)
 
 /* @
-type HashFunction domain {
+ghost type HashFunction domain {
     func hashFn(int) int
     func invFn(int) int
 

--- a/pkg/client/treeview.go
+++ b/pkg/client/treeview.go
@@ -77,87 +77,63 @@ func (tree *ImplicitBinarySearchTree) PathTo(node uint64 /*@, ghost p perm @*/) 
 	return
 }
 
+// Currently, magic wands do not get correctly processed by the SIF plugin
+// //@ requires  noPerm < p
+// //@ preserves tree != nil ==> acc(tree.Inv(), p)
+// //@ ensures   acc(path)
+// //@ ensures   tree != nil ==> len(path) > 0
+// func (tree *ImplicitBinarySearchTree) FrontierNodes( /*@ ghost p perm @*/ ) (path []uint64) {
+// 	path = []uint64{}
+
+// 	if tree == nil {
+// 		return
+// 	}
+
+// 	t := tree
+// 	//@ package acc(t.Inv(), p) --* acc(tree.Inv(), p)
+// 	// temporarily unfold the invariant to obtain the knowledge that t cannot be nil:
+// 	//@ assert unfolding acc(tree.Inv(), p) in t != nil
+
+// 	//@ invariant acc(path)
+// 	//@ invariant t != nil ==> acc(t.Inv(), p)
+// 	//@ invariant t != nil ==> acc(t.Inv(), p) --* acc(tree.Inv(), p)
+// 	//@ invariant t == nil ==> acc(tree.Inv(), p)
+// 	//@ invariant t == nil ==> len(path) > 0
+// 	for t != nil {
+// 		//@ unfold acc(t.Inv(), p)
+// 		path = append( /*@ p, @*/ path, t.Root)
+// 		//@ ghost oldT := t
+// 		t = t.Right
+// 		/*@
+// 		ghost if t == nil {
+// 			fold acc(oldT.Inv(), p)
+// 			apply acc(oldT.Inv(), p) --* acc(tree.Inv(), p)
+// 		} else {
+// 			package acc(t.Inv(), p) --* acc(tree.Inv(), p) {
+// 				fold acc(oldT.Inv(), p)
+// 				apply acc(oldT.Inv(), p) --* acc(tree.Inv(), p)
+// 			}
+// 		}
+// 		@*/
+// 	}
+// 	return
+// }
 //@ requires  noPerm < p
 //@ preserves tree != nil ==> acc(tree.Inv(), p)
 //@ ensures   acc(path)
 //@ ensures   tree != nil ==> len(path) > 0
 func (tree *ImplicitBinarySearchTree) FrontierNodes( /*@ ghost p perm @*/ ) (path []uint64) {
-	path = []uint64{}
-
 	if tree == nil {
 		return
 	}
 
-	t := tree
-	//@ package acc(t.Inv(), p) --* acc(tree.Inv(), p)
-	// temporarily unfold the invariant to obtain the knowledge that t cannot be nil:
-	//@ assert unfolding acc(tree.Inv(), p) in t != nil
-
-	//@ invariant acc(path)
-	//@ invariant t != nil ==> acc(t.Inv(), p)
-	//@ invariant t != nil ==> acc(t.Inv(), p) --* acc(tree.Inv(), p)
-	//@ invariant t == nil ==> acc(tree.Inv(), p)
-	//@ invariant t == nil ==> len(path) > 0
-	for t != nil {
-		//@ unfold acc(t.Inv(), p)
-		path = append( /*@ p, @*/ path, t.Root)
-		//@ ghost oldT := t
-		t = t.Right
-		/*@
-		ghost if t == nil {
-			fold acc(oldT.Inv(), p)
-			apply acc(oldT.Inv(), p) --* acc(tree.Inv(), p)
-		} else {
-			package acc(t.Inv(), p) --* acc(tree.Inv(), p) {
-				fold acc(oldT.Inv(), p)
-				apply acc(oldT.Inv(), p) --* acc(tree.Inv(), p)
-			}
-		}
-		@*/
-	}
+	//@ unfold acc(tree.Inv(), p)
+	path = []uint64{tree.Root}
+	subtreePath := tree.Right.FrontierNodes( /*@ p @*/ )
+	path = append( /*@ p, @*/ path, subtreePath...)
+	//@ fold acc(tree.Inv(), p)
 	return
 }
-
-// Currently, magic wands do not get correctly processed by the SIF plugin
-// //@ requires  noPerm < p
-// //@ preserves tree != nil ==> acc(tree.Inv(), p)
-// //@ ensures acc(path) && (tree != nil ==> len(path) > 0)
-// func (tree *ImplicitBinarySearchTree) FrontierNodesLoop(/*@ ghost p perm @*/) (path []uint64) {
-// 	path = []uint64{}
-
-// 	tmpTree := tree
-
-// 	/*@
-// 	ghost if tree != nil {
-// 		package acc(tmpTree.Inv(), p) --* acc(tree.Inv(), p)
-// 	}
-// 	@*/
-
-// 	//@ invariant acc(path)
-// 	//@ invariant tree != nil && tmpTree == nil ==> acc(tree.Inv(), p)
-// 	//@ invariant tmpTree != nil ==> acc(tmpTree.Inv(), p)
-// 	//@ invariant tmpTree != nil ==> acc(tmpTree.Inv(), p) --* acc(tree.Inv(), p)
-// 	//@ invariant tmpTree != tree ==> len(path) > 0
-// 	for tmpTree != nil {
-// 		//@ unfold acc(tmpTree.Inv(), p)
-// 		path = append(/*@ perm(1/2), @*/ path, tmpTree.Root)
-// 		oldTmpTree := tmpTree
-// 		_ = oldTmpTree
-// 		tmpTree = tmpTree.Right
-// 		/*@
-// 		ghost if tmpTree == nil {
-// 			fold acc(oldTmpTree.Inv(), p)
-// 			apply acc(oldTmpTree.Inv(), p) --* acc(tree.Inv(), p)
-// 		} else {
-// 			package acc(tmpTree.Inv(), p) --* acc(tree.Inv(), p) {
-// 				fold acc(oldTmpTree.Inv(), p)
-// 				apply acc(oldTmpTree.Inv(), p) --* acc(tree.Inv(), p)
-// 			}
-// 		}
-// 		@*/
-// 	}
-// 	return path
-// }
 
 //@ ensures tree_size != 0 ==> tree != nil
 //@ ensures tree != nil ==> tree.Inv()

--- a/pkg/prefixtree/prefixtree.go
+++ b/pkg/prefixtree/prefixtree.go
@@ -16,7 +16,7 @@ type Node struct {
 const InexistentSubtreeHash = -1
 
 /*@
-type BitConversion domain {
+ghost type BitConversion domain {
     func GetBits(uint64) seq[bool]
     func GetInt(seq[bool]) uint64
 
@@ -81,7 +81,7 @@ func test() {
 }
 
 /*@
-type Hashing domain {
+ghost type Hashing domain {
     // type 0
     func hashKeyValue(uint64, int) int
     func invKeyValue1(int) uint64

--- a/pkg/proofs/ladder.go
+++ b/pkg/proofs/ladder.go
@@ -1,18 +1,27 @@
 package proofs
 
 func FullBinaryLadderSteps(target uint32) (r []uint32) {
+	//@ assume 0 <= target // see https://github.com/viperproject/gobra/issues/192
 	r = make([]uint32, 0)
 	var i uint32 = 1
+
+	//@ invariant acc(r)
+	//@ invariant 0 <= i - 1
+	//@ invariant i-1 <= target || 1 <= len(r)
 	for i-1 <= target {
 		r = append( /*@ perm(1/2), @*/ r, i-1)
+		//@ old_i := i
 		i = i << 1
+		//@ assume i == old_i * 2 // Gobra currently does not axiomatize left and right shifts
 	}
 	// i is now the smallest power of two s.t. i-1 is larger than target
+	//@ assert target < i - 1
 
 	x_in := r[len(r)-1]
 	x_out := i - 1
 	r = append( /*@ perm(1/2), @*/ r, x_out) // this will be the first proof of non-inclusion
 
+	//@ invariant acc(r)
 	for ((x_out - x_in) / 2) > 0 {
 		next := x_in + ((x_out - x_in) / 2) - 1
 		r = append( /*@ perm(1/2), @*/ r, next)

--- a/pkg/proofs/prefixproof.go
+++ b/pkg/proofs/prefixproof.go
@@ -76,7 +76,7 @@ func (tree *PrefixTree) initializeAt(vrf_output [32]byte, depth uint8, sub_tree 
 // steps. We assume that the binary ladder steps are in the order that the
 // binary ladder would request them.
 func (prf PrefixProof) ToTree(fullLadder []BinaryLadderStep) (tree *PrefixTree, err error) {
-	tree = &PrefixTree{nil, nil, nil, nil}
+	tree = &PrefixTree{}
 	if len(fullLadder) < len(prf.Results) {
 		return nil, errors.New("too many results")
 	}


### PR DESCRIPTION
Updates this codebase to be compatible with the latest commit in Gobra's `hyperGobra` branch. The biggest difference is that ghost types (such as domains, ADTs) need the be prepended by the `ghost` keyword.
In addition, this PR
- fixes invalid pre- and postconditions in `prefixproof.go`, however without proving that the method bodies guarantee these postconditions
- made some progress in `ladder.go` in stating invariants to justify the memory accesses. However, I had to assume certain properties that Gobra does not yet provide
- changed `FrontierNode` to be recursive as the secure information flow plugin does not yet support magic wands, which would be necessary for the iterative implementation. While this package (i.e. `pkg/client`) currently verifies with `--hyperMode off`, it does not do so after enabling the hyper mode as some predicate instances seem to be missing in the frame (I've adapted the CI accordingly). This requires further investigation and probably a fix in the secure information flow plugin.

As long as a package or any imported package does not use secure information flow features (such as the `low` keyword), this PR brings the codebase up-to-speed with the latest nightly Gobra release, such that the Gobra-IDE VSCode extension becomes usable