### PR TITLE
[WIP] memory safety

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -129,8 +129,7 @@ jobs:
             --module ${{ env.MOD_NAME }} \
             --hyperMode off \
             --recursive \
-            --include "." ".verification" \
-            --includePackages "client"
+            --include "." ".verification"
 
       - name: Verify packages (with hyperMode)
         working-directory: keytrans-verification
@@ -140,7 +139,7 @@ jobs:
             --hyperMode extended \
             --recursive \
             --include "." ".verification" \
-            --excludePackages ${{ env.EXCLUDE_PKGS }} "client"
+            --excludePackages ${{ env.EXCLUDE_PKGS }}
 
       - name: Upload Gobra statistics
         if: ${{ always() }}

--- a/pkg/proofs/prefixproof.go
+++ b/pkg/proofs/prefixproof.go
@@ -7,19 +7,14 @@ import (
 
 /*@
 pred (t *PrefixTree) Inv() {
-	acc(t, _) && (t != nil ==> acc(t.InvRec(), 1))
-}
-
-pred (t *PrefixTree) InvRec() {
     t != nil ==> (
-        acc(&t.Value, _) && acc(&t.Leaf, _) && acc(&t.Left, _) && acc(&t.Right, _) &&
+        acc(&t.Value) && acc(&t.Leaf) && acc(&t.Left) && acc(&t.Right) &&
         (t.Left == nil  ==> t.Right == nil) &&
         (t.Right == nil ==> t.Left == nil) &&
-        (t.Value != nil ==> t.Leaf == nil && t.Left == nil && t.Right == nil && acc(t.Value, _)) &&
-        (t.Leaf  != nil ==> t.Value == nil && t.Left == nil && t.Right == nil && acc(t.Leaf, _) &&
-                             acc(&(t.Leaf).Vrf_output, _) && acc(&(t.Leaf).Commitment, _)) &&
-        (t.Left  != nil ==> t.Value == nil && t.Leaf == nil && acc(t.Left.Inv(), 1)) &&
-        (t.Right != nil ==> t.Value == nil && t.Leaf == nil && acc(t.Right.Inv(), 1)))
+        (t.Value != nil ==> t.Leaf == nil && t.Left == nil && t.Right == nil && acc(t.Value)) &&
+        (t.Leaf  != nil ==> t.Value == nil && t.Left == nil && t.Right == nil && acc(t.Leaf)) &&
+        (t.Left  != nil ==> t.Value == nil && t.Leaf == nil && acc(t.Left.Inv())) &&
+        (t.Right != nil ==> t.Value == nil && t.Leaf == nil && acc(t.Right.Inv())))
 }
 @*/
 
@@ -28,7 +23,7 @@ pred (t *PrefixTree) InvRec() {
 // @ decreases
 // @ pure
 func (t *PrefixTree) GetValue() *[sha256.Size]byte {
-	return /*@ unfolding acc(t.Inv(), _) in unfolding acc(t.InvRec(), _) in @*/ t.Value
+	return /*@ unfolding acc(t.Inv(), 1/2) in @*/ t.Value
 }
 
 // @ requires t != nil
@@ -37,7 +32,7 @@ func (t *PrefixTree) GetValue() *[sha256.Size]byte {
 // @ decreases
 // @ pure
 func (t *PrefixTree) GetValueArray() [sha256.Size]byte {
-	return /*@ unfolding acc(t.Inv(), _) in unfolding acc(t.InvRec(), _) in @*/ *t.Value
+	return /*@ unfolding acc(t.Inv(), 1/2) in @*/ *t.Value
 }
 
 // Recursive prefix tree data structure
@@ -61,10 +56,12 @@ type PrefixTree struct {
 // TODO(cfm): Are any of these pre/post-conditions invariants?
 // @ requires forall i int :: { &prefix[i] } 0 <= i && i < len(prefix) ==> acc(&prefix[i], 1/2)
 // @ requires forall i int :: { steps[i] } 0 <= i && i < len(steps) ==> acc(&steps[i], 1/2)
+// @ requires forall i int :: { &steps[i] } 0 <= i && i < len(steps) ==> acc((&steps[i]).Inv(), 1/2)
 // @ requires forall i int :: { coPathNodes[i] } 0 <= i && i < len(coPathNodes) ==> acc(&coPathNodes[i], _)
 // @ ensures err == nil ==> tree != nil && acc(tree.Inv())
 // @ ensures err == nil ==> forall i, j int :: { &nextSteps[i], &nextSteps[j] } 0 <= i && i < len(nextSteps) && 0 <= j && j < len(nextSteps) && i != j ==> &nextSteps[i] != &nextSteps[j]
 // @ ensures err == nil ==> forall i int :: { &nextSteps[i] } 0 <= i && i < len(nextSteps) ==> acc(&nextSteps[i], 1/2)
+// @ ensures err == nil ==> forall i int :: { &nextSteps[i] } 0 <= i && i < len(nextSteps) ==> acc((&nextSteps[i]).Inv(), 1/2)
 // @ ensures err == nil ==> forall i int :: { &nextNodes[i] } 0 <= i && i < len(nextNodes) ==> acc(&nextNodes[i], _)
 // @ ensures err == nil ==> forall i, j int :: { &nextNodes[i], &nextNodes[j] } 0 <= i && i < len(nextNodes) && 0 <= j && j < len(nextNodes) && i != j ==> &nextNodes[i] != &nextNodes[j]
 func ToTreeRecursive(prefix []bool, steps []CompleteBinaryLadderStep, coPathNodes []NodeValue) (tree *PrefixTree, nextSteps []CompleteBinaryLadderStep, nextNodes []NodeValue, err error) {
@@ -84,7 +81,6 @@ func ToTreeRecursive(prefix []bool, steps []CompleteBinaryLadderStep, coPathNode
 			val /* @@@ */ := coPathNodes[0]
 			tree = &PrefixTree{Value: &val}
 			//@ assert tree != nil && tree.Value != nil && tree.Leaf == nil && tree.Left == nil && tree.Right == nil
-			//@ fold tree.InvRec()
 			//@ fold tree.Inv()
 			//@ assert forall i, j int :: { &nextSteps[i], &nextSteps[j] } 0 <= i && i < len(nextSteps) && 0 <= j && j < len(nextSteps) && i != j ==> &nextSteps[i] != &nextSteps[j]
 			nextNodes = coPathNodes[1:]
@@ -138,7 +134,6 @@ func ToTreeRecursive(prefix []bool, steps []CompleteBinaryLadderStep, coPathNode
 					valLeft /* @@@ */ := coPathNodes[0]
 					left := &PrefixTree{Value: &valLeft}
 					//@ assert left != nil && left.Value != nil && left.Leaf == nil && left.Left == nil && left.Right == nil
-					//@ fold left.InvRec()
 					//@ fold left.Inv()
 					tail := coPathNodes[1:]
 					//@ assert forall i, j int :: { &tail[i], &tail[j] } 0 <= i && i < len(tail) && 0 <= j && j < len(tail) && i != j ==> &tail[i] != &tail[j]
@@ -152,7 +147,6 @@ func ToTreeRecursive(prefix []bool, steps []CompleteBinaryLadderStep, coPathNode
 					} else {
 						tree = &PrefixTree{Left: left, Right: right}
 						//@ assert tree != nil && tree.Value == nil && tree.Leaf == nil && tree.Left != nil && tree.Right != nil
-						//@ fold tree.InvRec()
 						//@ fold tree.Inv()
 						nextSteps = recSteps
 						//@ assert forall i, j int :: 0 <= i && i < len(nextSteps) && 0 <= j && j < len(nextSteps) && i != j ==> &nextSteps[i] != &nextSteps[j]
@@ -180,7 +174,6 @@ func ToTreeRecursive(prefix []bool, steps []CompleteBinaryLadderStep, coPathNode
 					} else {
 						tree = &PrefixTree{Left: left, Right: right}
 						//@ assert tree != nil && tree.Value == nil && tree.Leaf == nil && tree.Left != nil && tree.Right != nil
-						//@ fold tree.InvRec()
 						//@ fold tree.Inv()
 						nextSteps = recSteps2
 						//@ assert forall i, j int :: 0 <= i && i < len(nextSteps) && 0 <= j && j < len(nextSteps) && i != j ==> &nextSteps[i] != &nextSteps[j]
@@ -194,10 +187,12 @@ func ToTreeRecursive(prefix []bool, steps []CompleteBinaryLadderStep, coPathNode
 			// on the type of result.
 			resultType := step.Result.Result_type
 			if resultType == Inclusion {
-				leaf /* @@@ */ := step.Step
-				tree = &PrefixTree{Leaf: &leaf}
-				//@ assert tree != nil && tree.Leaf != nil && tree.Value == nil && tree.Left == nil && tree.Right == nil
-				//@ fold tree.InvRec()
+				leafp /* @@@ */ := new(PrefixLeaf)
+				leafp.Vrf_output = step.Step.Vrf_output
+				leafp.Commitment = step.Step.Commitment
+				tree = &PrefixTree{Leaf: leafp}
+				//@ assert tree != nil && tree.Value == nil && tree.Left == nil && tree.Right == nil
+				//@ assert acc(leafp) && acc(&tree.Leaf) && tree.Leaf == leafp
 				//@ fold tree.Inv()
 				nextSteps = steps[1:]
 				//@ assert forall i int :: { &nextSteps[i] } 0 <= i && i < len(nextSteps) ==> &nextSteps[i] == &steps[i+1]
@@ -209,10 +204,15 @@ func ToTreeRecursive(prefix []bool, steps []CompleteBinaryLadderStep, coPathNode
 					err = errors.New("no leaf for inclusion proof given")
 					return
 				} else {
-					leaf /* @@@ */ := step.Result.Leaf
-					tree = &PrefixTree{Leaf: leaf}
+					leafp /* @@@ */ := new(PrefixLeaf)
+					//@ unfold acc((&steps[0]).Inv(), 1/2)
+					//@ assert acc(&(steps[0].Result.Leaf).Vrf_output, 1/2) && acc(&(steps[0].Result.Leaf).Commitment, 1/2)
+					leafp.Vrf_output = steps[0].Result.Leaf.Vrf_output
+					leafp.Commitment = steps[0].Result.Leaf.Commitment
+					//@ fold acc((&steps[0]).Inv(), 1/2)
+					tree = &PrefixTree{Leaf: leafp}
 					//@ assert tree != nil && tree.Leaf != nil && tree.Value == nil && tree.Left == nil && tree.Right == nil
-					//@ fold tree.InvRec()
+					//@ assert acc(leafp) && acc(&tree.Leaf) && tree.Leaf == leafp
 					//@ fold tree.Inv()
 					nextSteps = steps[1:]
 					//@ assert forall i int :: { &nextSteps[i] } 0 <= i && i < len(nextSteps) ==> &nextSteps[i] == &steps[i+1]
@@ -223,7 +223,6 @@ func ToTreeRecursive(prefix []bool, steps []CompleteBinaryLadderStep, coPathNode
 			} else if resultType == NonInclusionParent {
 				tree = &PrefixTree{Value: &[32]byte{}}
 				//@ assert tree != nil && tree.Value != nil && tree.Leaf == nil && tree.Left == nil && tree.Right == nil
-				//@ fold tree.InvRec()
 				//@ fold tree.Inv()
 				nextSteps = steps[1:]
 				//@ assert forall i int :: { &nextSteps[i] } 0 <= i && i < len(nextSteps) ==> &nextSteps[i] == &steps[i+1]
@@ -245,7 +244,6 @@ func ToTreeRecursive(prefix []bool, steps []CompleteBinaryLadderStep, coPathNode
 		val /* @@@ */ := coPathNodes[0]
 		tree = &PrefixTree{Value: &val}
 		//@ assert tree != nil && tree.Value != nil && tree.Leaf == nil && tree.Left == nil && tree.Right == nil
-		//@ fold tree.InvRec()
 		//@ fold tree.Inv()
 		//@ assert forall i, j int :: { &nextSteps[i], &nextSteps[j] } 0 <= i && i < len(nextSteps) && 0 <= j && j < len(nextSteps) && i != j ==> &nextSteps[i] != &nextSteps[j]
 		nextNodes = coPathNodes[1:]
@@ -280,6 +278,7 @@ func (prf PrefixProof) ToTree(fullLadder []BinaryLadderStep) (tree *PrefixTree, 
 	//@ unfold acc(prf.Inv(), 1/2)
 	//@ assert forall i int :: { &prf.Elements[i] } 0 <= i && i < len(prf.Elements) ==> acc(&prf.Elements[i], _)
 	//@ assert forall i, j int :: { &prf.Elements[i], &prf.Elements[j] } 0 <= i && i < len(prf.Elements) && 0 <= j && j < len(prf.Elements) && i != j ==> &prf.Elements[i] != &prf.Elements[j]
+	//@ assert forall i int :: { steps[i] } 0 <= i && i < len(steps) ==> acc(&steps[i], 1/2)
 	if tree, _, _, err = ToTreeRecursive([]bool{}, steps, prf.Elements); err != nil {
 		//@ fold acc(prf.Inv(), 1/2)
 		return
@@ -297,7 +296,7 @@ func (tree *PrefixTree) HashContent() (hashContent []byte, err error) {
 	hashContent = make([]byte, sha256.Size+1)
 	if tree == nil {
 		return hashContent, nil
-	} else if /*@ unfolding acc(tree.Inv(), _) in unfolding acc(tree.InvRec(), _) in @*/ tree.Left == nil && tree.Right == nil {
+	} else if /*@ unfolding acc(tree.Inv(), 1/2) in @*/ tree.Left == nil && tree.Right == nil {
 		if value /*@ @ @*/, err := tree.ComputeHash(); err != nil {
 			return nil, err
 		} else {
@@ -305,17 +304,13 @@ func (tree *PrefixTree) HashContent() (hashContent []byte, err error) {
 		}
 	} else {
 		//@ unfold acc(tree.Inv(), 1/2)
-		//@ unfold acc(tree.InvRec(), 1/2)
 		if leftContent, err := tree.Left.HashContent(); err != nil {
-			//@ fold acc(tree.InvRec(), 1/2)
 			//@ fold acc(tree.Inv(), 1/2)
 			return nil, err
 		} else if rightContent, err := tree.Right.HashContent(); err != nil {
-			//@ fold acc(tree.InvRec(), 1/2)
 			//@ fold acc(tree.Inv(), 1/2)
 			return nil, err
 		} else {
-			//@ fold acc(tree.InvRec(), 1/2)
 			//@ fold acc(tree.Inv(), 1/2)
 			buf := make([]byte, 1+len(leftContent)+len(rightContent))
 			buf[0] = 0x02
@@ -332,23 +327,21 @@ func (tree *PrefixTree) HashContent() (hashContent []byte, err error) {
 func (tree *PrefixTree) ComputeHash() (hash [sha256.Size]byte, err error) {
 	if tree == nil {
 		return [sha256.Size]byte{}, errors.New("cannot hash empty node")
-	} else if /*@ unfolding acc(tree.Inv(), _) in unfolding acc(tree.InvRec(), _) in @*/ tree.Value != nil {
-		return /*@ unfolding acc(tree.Inv(), _) in unfolding acc(tree.InvRec(), _) in @*/ *tree.Value, nil
-	} else if /*@ unfolding acc(tree.Inv(), _) in unfolding acc(tree.InvRec(), _) in @*/ tree.Left == nil && tree.Right == nil {
-		if /*@ unfolding acc(tree.Inv(), _) in unfolding acc(tree.InvRec(), _) in @*/ tree.Leaf == nil {
+	} else if /*@ unfolding acc(tree.Inv(), 1/2) in @*/ tree.Value != nil {
+		return /*@ unfolding acc(tree.Inv(), 1/2) in @*/ *tree.Value, nil
+	} else if /*@ unfolding acc(tree.Inv(), 1/2) in @*/ tree.Left == nil && tree.Right == nil {
+		if /*@ unfolding acc(tree.Inv(), 1/2) in @*/ tree.Leaf == nil {
 			return [sha256.Size]byte{}, errors.New("neither leaf nor value given for empty node")
 		} else {
 			// TODO: We would have to include length, too, to be compliant with TLS
 			// encoding, but not so important right now because inputs are
 			// fixed-length and this may get changed in the future
 			//@ unfold acc(tree.Inv(), 1/2)
-			//@ unfold acc(tree.InvRec(), 1/2)
 			buf := make([]byte, len(tree.Leaf.Vrf_output)+len(tree.Leaf.Commitment))
 			_ = copy(buf, tree.Leaf.Vrf_output[:] /*@ , perm(1/2) @*/)
 			_ = copy(buf[len(tree.Leaf.Vrf_output):], tree.Leaf.Commitment[:] /*@ , perm(1/2) @*/)
 			value /*@ @ @*/ := sha256.Sum256(buf /*@ , perm(1/2) @*/)
 			tree.Value = &value
-			//@ fold acc(tree.InvRec(), 1/2)
 			//@ fold acc(tree.Inv(), 1/2)
 			return value, nil
 		}

--- a/pkg/proofs/prefixproof.go
+++ b/pkg/proofs/prefixproof.go
@@ -7,35 +7,35 @@ import (
 
 /*@
 pred (t *PrefixTree) Inv() {
-	acc(t) && (t != nil ==> t.InvRec())
+	acc(t, _) && (t != nil ==> acc(t.InvRec(), 1))
 }
 
-pred (t PrefixTree) InvRec() {
-	acc(t.Value) && acc(t.Leaf) && acc(t.Left) && acc(t.Right) &&
-	// One of value, leaf, or both children must be defined
-	(t.Value != nil || t.Leaf != nil || (t.Left != nil && t.Right != nil)) &&
-	// If there's one children, there must be two
-	(t.Left != nil) == (t.Right != nil) &&
-	// Node is either a leaf or has children
-	(t.Leaf != nil) != (t.Left != nil && t.Right != nil) &&
-	// If a node's value is defined, its children's values must be defined
-	((t.Value != nil && t.Left != nil && t.Right != nil) ==> (t.Left.Value != nil && t.Right.Value != nil))
+pred (t *PrefixTree) InvRec() {
+    t != nil ==> (
+        acc(&t.Value, _) && acc(&t.Leaf, _) && acc(&t.Left, _) && acc(&t.Right, _) &&
+        (t.Left == nil  ==> t.Right == nil) &&
+        (t.Right == nil ==> t.Left == nil) &&
+        (t.Value != nil ==> t.Leaf == nil && t.Left == nil && t.Right == nil && acc(t.Value, _)) &&
+        (t.Leaf  != nil ==> t.Value == nil && t.Left == nil && t.Right == nil && acc(t.Leaf, _) &&
+                             acc(&(t.Leaf).Vrf_output, _) && acc(&(t.Leaf).Commitment, _)) &&
+        (t.Left  != nil ==> t.Value == nil && t.Leaf == nil && acc(t.Left.Inv(), 1)) &&
+        (t.Right != nil ==> t.Value == nil && t.Leaf == nil && acc(t.Right.Inv(), 1)))
 }
 @*/
 
-//@ requires t != nil
-//@ requires acc(t.Inv(), _)
-//@ decreases
-//@ pure
+// @ requires t != nil
+// @ requires acc(t.Inv(), _)
+// @ decreases
+// @ pure
 func (t *PrefixTree) GetValue() *[sha256.Size]byte {
 	return /*@ unfolding acc(t.Inv(), _) in unfolding acc(t.InvRec(), _) in @*/ t.Value
 }
 
-//@ requires t != nil
-//@ requires acc(t.Inv(), _)
-//@ requires t.GetValue() != nil
-//@ decreases
-//@ pure
+// @ requires t != nil
+// @ requires acc(t.Inv(), _)
+// @ requires t.GetValue() != nil
+// @ decreases
+// @ pure
 func (t *PrefixTree) GetValueArray() [sha256.Size]byte {
 	return /*@ unfolding acc(t.Inv(), _) in unfolding acc(t.InvRec(), _) in @*/ *t.Value
 }
@@ -58,12 +58,21 @@ type PrefixTree struct {
 // ascending by steps.Step.Vrf_output and that coPathNodes is sorted ascending
 // too. prefix will be initially empty and reflects the current position in the
 // prefix tree.
-//@ ensures err != nil ==> tree != nil && tree.Inv()
+// TODO(cfm): Are any of these pre/post-conditions invariants?
+// @ requires forall i int :: { &prefix[i] } 0 <= i && i < len(prefix) ==> acc(&prefix[i], 1/2)
+// @ requires forall i int :: { steps[i] } 0 <= i && i < len(steps) ==> acc(&steps[i], 1/2)
+// @ requires forall i int :: { coPathNodes[i] } 0 <= i && i < len(coPathNodes) ==> acc(&coPathNodes[i], _)
+// @ ensures err == nil ==> tree != nil && acc(tree.Inv())
+// @ ensures err == nil ==> forall i, j int :: { &nextSteps[i], &nextSteps[j] } 0 <= i && i < len(nextSteps) && 0 <= j && j < len(nextSteps) && i != j ==> &nextSteps[i] != &nextSteps[j]
+// @ ensures err == nil ==> forall i int :: { &nextSteps[i] } 0 <= i && i < len(nextSteps) ==> acc(&nextSteps[i], 1/2)
+// @ ensures err == nil ==> forall i int :: { &nextNodes[i] } 0 <= i && i < len(nextNodes) ==> acc(&nextNodes[i], _)
+// @ ensures err == nil ==> forall i, j int :: { &nextNodes[i], &nextNodes[j] } 0 <= i && i < len(nextNodes) && 0 <= j && j < len(nextNodes) && i != j ==> &nextNodes[i] != &nextNodes[j]
 func ToTreeRecursive(prefix []bool, steps []CompleteBinaryLadderStep, coPathNodes []NodeValue) (tree *PrefixTree, nextSteps []CompleteBinaryLadderStep, nextNodes []NodeValue, err error) {
 	tree = nil
 	nextSteps = steps
 	nextNodes = coPathNodes
 	err = nil
+	//@ assert forall i, j int :: { &coPathNodes[i], &coPathNodes[j] } 0 <= i && i < len(coPathNodes) && 0 <= j && j < len(coPathNodes) && i != j ==> &coPathNodes[i] != &coPathNodes[j]
 
 	// If there are no more steps to insert into the prefix tree, insert a copath
 	// node at the current subtree.
@@ -72,18 +81,36 @@ func ToTreeRecursive(prefix []bool, steps []CompleteBinaryLadderStep, coPathNode
 			err = errors.New("not enough co-path nodes")
 			return
 		} else {
-			tree = &PrefixTree{Value: &coPathNodes[0]}
+			val /* @@@ */ := coPathNodes[0]
+			tree = &PrefixTree{Value: &val}
+			//@ assert tree != nil && tree.Value != nil && tree.Leaf == nil && tree.Left == nil && tree.Right == nil
+			//@ fold tree.InvRec()
+			//@ fold tree.Inv()
+			//@ assert forall i, j int :: { &nextSteps[i], &nextSteps[j] } 0 <= i && i < len(nextSteps) && 0 <= j && j < len(nextSteps) && i != j ==> &nextSteps[i] != &nextSteps[j]
 			nextNodes = coPathNodes[1:]
+			//@ assert forall i int :: { &nextSteps[i] } 0 <= i && i < len(nextSteps) ==> &nextSteps[i] == &steps[i]
+			//@ assert forall i int :: { &nextSteps[i] } 0 <= i && i < len(nextSteps) ==> acc(&nextSteps[i], 1/2)
+			//@ assert forall i int :: { &nextNodes[i] } 0 <= i && i < len(nextNodes) ==> &nextNodes[i] == &coPathNodes[i+1]
+			//@ assert forall i, j int :: { &nextNodes[i], &nextNodes[j] } 0 <= i && i < len(nextNodes) && 0 <= j && j < len(nextNodes) && i != j ==> &nextNodes[i] != &nextNodes[j]
 			return
 		}
 	}
 
-	step /*@@@*/ := steps[0]
+	step := steps[0]
 
 	prefixMatches := false
-	for i := 0; i < len(prefix); i++ {
-		bit := step.Step.Vrf_output[i/8]>>(i%8) == 0x01
-		prefixMatches = prefixMatches && bit == prefix[i]
+	if len(prefix) > len(step.Step.Vrf_output)*8 {
+		err = errors.New("prefix longer than VRF output")
+		return
+	} else if len(prefix) > 0 {
+		//@ invariant 0 <= i && i <= len(prefix)
+		//@ invariant forall j int :: { &prefix[j] } 0 <= j && j < len(prefix) ==> acc(&prefix[j], 1/2)
+		for i := 0; i < len(prefix); i++ {
+			//@ assert 0 <= i && i < len(prefix)
+			b := step.Step.Vrf_output[i/8]
+			bit := ((b >> uint(i%8)) & 1) == 1
+			prefixMatches = prefixMatches && bit == prefix[i]
+		}
 	}
 
 	if prefixMatches {
@@ -92,7 +119,14 @@ func ToTreeRecursive(prefix []bool, steps []CompleteBinaryLadderStep, coPathNode
 			// The server tells us that this depth does suffice to identify the
 			// vrf output. Insert the result in one of its children.
 			nextDepth := len(prefix) + 1
-			nextBit := step.Step.Vrf_output[nextDepth/8]>>(nextDepth%8) == 0x01
+			if nextDepth >= len(step.Step.Vrf_output)*8 {
+				err = errors.New("next depth exceeds VRF output size")
+				return
+			}
+			byteIndex := nextDepth / 8
+			//@ assert 0 <= byteIndex && byteIndex < len(step.Step.Vrf_output)
+			b := step.Step.Vrf_output[byteIndex]
+			nextBit := ((b >> uint(nextDepth%8)) & 1) == 1
 			if nextBit {
 				// Go right
 				if len(coPathNodes) == 0 {
@@ -101,13 +135,27 @@ func ToTreeRecursive(prefix []bool, steps []CompleteBinaryLadderStep, coPathNode
 				} else {
 					// As we must recurse right, the left child must be provided as a co
 					// path node.
-					left := &PrefixTree{Value: &coPathNodes[0]}
-					if right, recSteps, recNodes, e := ToTreeRecursive(append( /*@ perm(1/2), @*/ prefix, true), steps, coPathNodes[1:]); e != nil {
+					valLeft /* @@@ */ := coPathNodes[0]
+					left := &PrefixTree{Value: &valLeft}
+					//@ assert left != nil && left.Value != nil && left.Leaf == nil && left.Left == nil && left.Right == nil
+					//@ fold left.InvRec()
+					//@ fold left.Inv()
+					tail := coPathNodes[1:]
+					//@ assert forall i, j int :: { &tail[i], &tail[j] } 0 <= i && i < len(tail) && 0 <= j && j < len(tail) && i != j ==> &tail[i] != &tail[j]
+					//@ assert forall i int :: { &tail[i] } 0 <= i && i < len(tail) ==> &tail[i] == &coPathNodes[i+1]
+					pRight := make([]bool, len(prefix)+1)
+					copy(pRight, prefix /*@, perm(1/2) @*/)
+					pRight[len(prefix)] = true
+					if right, recSteps, recNodes, e := ToTreeRecursive(pRight, steps, tail); e != nil {
 						err = e
 						return
 					} else {
 						tree = &PrefixTree{Left: left, Right: right}
+						//@ assert tree != nil && tree.Value == nil && tree.Leaf == nil && tree.Left != nil && tree.Right != nil
+						//@ fold tree.InvRec()
+						//@ fold tree.Inv()
 						nextSteps = recSteps
+						//@ assert forall i, j int :: 0 <= i && i < len(nextSteps) && 0 <= j && j < len(nextSteps) && i != j ==> &nextSteps[i] != &nextSteps[j]
 						nextNodes = recNodes
 						return
 					}
@@ -116,17 +164,29 @@ func ToTreeRecursive(prefix []bool, steps []CompleteBinaryLadderStep, coPathNode
 				// Go left. Continue with the algorithm recursively to the right
 				// afterwards. Either, the next step may be inserted there or it is
 				// provided as a co path node.
-				if left, recSteps, recNodes, e := ToTreeRecursive(append( /*@ perm(1/2), @*/ prefix, false), steps, coPathNodes); e != nil {
-					err = e
-					return
-				} else if right, recSteps2, recNodes2, e := ToTreeRecursive(append( /*@ perm(1/2), @*/ prefix, false), recSteps, recNodes); e != nil {
+				//@ assert forall i int :: { &prefix[i] } 0 <= i && i < len(prefix) ==> acc(&prefix[i], 1/2)
+				pLeft1 := make([]bool, len(prefix)+1)
+				copy(pLeft1, prefix /*@, perm(1/2) @*/)
+				pLeft1[len(prefix)] = false
+				if left, recSteps, recNodes, e := ToTreeRecursive(pLeft1, steps, coPathNodes); e != nil {
 					err = e
 					return
 				} else {
-					tree = &PrefixTree{Left: left, Right: right}
-					nextSteps = recSteps2
-					nextNodes = recNodes2
-					return
+					//@ assert forall i, j int :: { &recSteps[i], &recSteps[j] } 0 <= i && i < len(recSteps) && 0 <= j && j < len(recSteps) && i != j ==> &recSteps[i] != &recSteps[j]
+					//@ assert forall i, j int :: { &recNodes[i], &recNodes[j] } 0 <= i && i < len(recNodes) && 0 <= j && j < len(recNodes) && i != j ==> &recNodes[i] != &recNodes[j]
+					if right, recSteps2, recNodes2, e := ToTreeRecursive(pLeft1, recSteps, recNodes); e != nil {
+						err = e
+						return
+					} else {
+						tree = &PrefixTree{Left: left, Right: right}
+						//@ assert tree != nil && tree.Value == nil && tree.Leaf == nil && tree.Left != nil && tree.Right != nil
+						//@ fold tree.InvRec()
+						//@ fold tree.Inv()
+						nextSteps = recSteps2
+						//@ assert forall i, j int :: 0 <= i && i < len(nextSteps) && 0 <= j && j < len(nextSteps) && i != j ==> &nextSteps[i] != &nextSteps[j]
+						nextNodes = recNodes2
+						return
+					}
 				}
 			}
 		} else if int(step.Result.Depth) == len(prefix) {
@@ -134,23 +194,41 @@ func ToTreeRecursive(prefix []bool, steps []CompleteBinaryLadderStep, coPathNode
 			// on the type of result.
 			resultType := step.Result.Result_type
 			if resultType == Inclusion {
-				// TODO: Copy leaf
-				tree = &PrefixTree{Leaf: &step.Step}
+				leaf /* @@@ */ := step.Step
+				tree = &PrefixTree{Leaf: &leaf}
+				//@ assert tree != nil && tree.Leaf != nil && tree.Value == nil && tree.Left == nil && tree.Right == nil
+				//@ fold tree.InvRec()
+				//@ fold tree.Inv()
 				nextSteps = steps[1:]
+				//@ assert forall i int :: { &nextSteps[i] } 0 <= i && i < len(nextSteps) ==> &nextSteps[i] == &steps[i+1]
+				//@ assert forall i int :: { &nextSteps[i] } 0 <= i && i < len(nextSteps) ==> acc(&nextSteps[i], 1/2)
+				//@ assert forall i, j int :: 0 <= i && i < len(nextSteps) && 0 <= j && j < len(nextSteps) && i != j ==> &nextSteps[i] != &nextSteps[j]
 				return
 			} else if resultType == NonInclusionLeaf {
 				if step.Result.Leaf == nil {
 					err = errors.New("no leaf for inclusion proof given")
 					return
 				} else {
-					// TODO: copy leaf
-					tree = &PrefixTree{Leaf: step.Result.Leaf}
+					leaf /* @@@ */ := step.Result.Leaf
+					tree = &PrefixTree{Leaf: leaf}
+					//@ assert tree != nil && tree.Leaf != nil && tree.Value == nil && tree.Left == nil && tree.Right == nil
+					//@ fold tree.InvRec()
+					//@ fold tree.Inv()
 					nextSteps = steps[1:]
+					//@ assert forall i int :: { &nextSteps[i] } 0 <= i && i < len(nextSteps) ==> &nextSteps[i] == &steps[i+1]
+					//@ assert forall i int :: { &nextSteps[i] } 0 <= i && i < len(nextSteps) ==> acc(&nextSteps[i], 1/2)
+					//@ assert forall i, j int :: 0 <= i && i < len(nextSteps) && 0 <= j && j < len(nextSteps) && i != j ==> &nextSteps[i] != &nextSteps[j]
 					return
 				}
 			} else if resultType == NonInclusionParent {
 				tree = &PrefixTree{Value: &[32]byte{}}
+				//@ assert tree != nil && tree.Value != nil && tree.Leaf == nil && tree.Left == nil && tree.Right == nil
+				//@ fold tree.InvRec()
+				//@ fold tree.Inv()
 				nextSteps = steps[1:]
+				//@ assert forall i int :: { &nextSteps[i] } 0 <= i && i < len(nextSteps) ==> &nextSteps[i] == &steps[i+1]
+				//@ assert forall i int :: { &nextSteps[i] } 0 <= i && i < len(nextSteps) ==> acc(&nextSteps[i], 1/2)
+				//@ assert forall i, j int :: 0 <= i && i < len(nextSteps) && 0 <= j && j < len(nextSteps) && i != j ==> &nextSteps[i] != &nextSteps[j]
 				return
 			} else {
 				err = errors.New("invalid result type")
@@ -164,8 +242,17 @@ func ToTreeRecursive(prefix []bool, steps []CompleteBinaryLadderStep, coPathNode
 		err = errors.New("not enough co-path nodes")
 		return
 	} else {
-		tree = &PrefixTree{Value: &coPathNodes[0]}
+		val /* @@@ */ := coPathNodes[0]
+		tree = &PrefixTree{Value: &val}
+		//@ assert tree != nil && tree.Value != nil && tree.Leaf == nil && tree.Left == nil && tree.Right == nil
+		//@ fold tree.InvRec()
+		//@ fold tree.Inv()
+		//@ assert forall i, j int :: { &nextSteps[i], &nextSteps[j] } 0 <= i && i < len(nextSteps) && 0 <= j && j < len(nextSteps) && i != j ==> &nextSteps[i] != &nextSteps[j]
 		nextNodes = coPathNodes[1:]
+		//@ assert forall i int :: { &nextSteps[i] } 0 <= i && i < len(nextSteps) ==> &nextSteps[i] == &steps[i]
+		//@ assert forall i int :: { &nextSteps[i] } 0 <= i && i < len(nextSteps) ==> acc(&nextSteps[i], 1/2)
+		//@ assert forall i int :: { &nextNodes[i] } 0 <= i && i < len(nextNodes) ==> &nextNodes[i] == &coPathNodes[i+1]
+		//@ assert forall i, j int :: { &nextNodes[i], &nextNodes[j] } 0 <= i && i < len(nextNodes) && 0 <= j && j < len(nextNodes) && i != j ==> &nextNodes[i] != &nextNodes[j]
 		return
 	}
 }
@@ -173,7 +260,9 @@ func ToTreeRecursive(prefix []bool, steps []CompleteBinaryLadderStep, coPathNode
 // Construct a prefix tree from a prefix proof and the provided binary ladder
 // steps. We assume that the binary ladder steps are in the order that the
 // binary ladder would request them.
-//@ ensures err != nil ==> tree != nil && tree.Inv() && tree.GetValue() != nil
+// @ requires prf.Inv()
+// @ requires forall i int :: { fullLadder[i] } 0 <= i && i < len(fullLadder) ==> acc(&fullLadder[i], 1/2)
+// @ ensures err == nil ==> tree != nil && tree.Inv()
 func (prf PrefixProof) ToTree(fullLadder []BinaryLadderStep) (tree *PrefixTree, err error) {
 	tree = &PrefixTree{}
 	if len(fullLadder) < len(prf.Results) {
@@ -181,60 +270,86 @@ func (prf PrefixProof) ToTree(fullLadder []BinaryLadderStep) (tree *PrefixTree, 
 	}
 
 	var steps []CompleteBinaryLadderStep
+	//@ unfold acc(prf.Inv(), 1/2)
 	if steps, err = CombineResults(prf.Results, fullLadder); err != nil {
+		//@ fold acc(prf.Inv(), 1/2)
 		return nil, err
 	}
+	//@ fold acc(prf.Inv(), 1/2)
 
+	//@ unfold acc(prf.Inv(), 1/2)
+	//@ assert forall i int :: { &prf.Elements[i] } 0 <= i && i < len(prf.Elements) ==> acc(&prf.Elements[i], _)
+	//@ assert forall i, j int :: { &prf.Elements[i], &prf.Elements[j] } 0 <= i && i < len(prf.Elements) && 0 <= j && j < len(prf.Elements) && i != j ==> &prf.Elements[i] != &prf.Elements[j]
 	if tree, _, _, err = ToTreeRecursive([]bool{}, steps, prf.Elements); err != nil {
+		//@ fold acc(prf.Inv(), 1/2)
 		return
 	}
+	//@ unfold acc(tree.Inv(), 1/2)
 	_, err = tree.ComputeHash()
+	//@ fold acc(tree.Inv(), 1/2)
+	//@ fold acc(prf.Inv(), 1/2)
 	return
 }
 
-//@ requires tree != nil ==> tree.Inv()
-//@ ensures  tree != nil ==> tree.Inv()
-//@ ensures  err != nil && tree != nil ==> tree.GetValue() != nil
+// @ preserves acc(tree.Inv(), 1/2)
+// @ ensures err == nil && tree != nil ==> forall i int :: { &hashContent[i] } 0 <= i && i < len(hashContent) ==> acc(&hashContent[i])
 func (tree *PrefixTree) HashContent() (hashContent []byte, err error) {
 	hashContent = make([]byte, sha256.Size+1)
 	if tree == nil {
 		return hashContent, nil
-	} else if tree.Left == nil && tree.Right == nil {
+	} else if /*@ unfolding acc(tree.Inv(), _) in unfolding acc(tree.InvRec(), _) in @*/ tree.Left == nil && tree.Right == nil {
 		if value /*@ @ @*/, err := tree.ComputeHash(); err != nil {
 			return nil, err
 		} else {
 			return append( /*@ perm(1/2), @*/ []byte{0x01}, value[:]...), nil
 		}
 	} else {
+		//@ unfold acc(tree.Inv(), 1/2)
+		//@ unfold acc(tree.InvRec(), 1/2)
 		if leftContent, err := tree.Left.HashContent(); err != nil {
+			//@ fold acc(tree.InvRec(), 1/2)
+			//@ fold acc(tree.Inv(), 1/2)
 			return nil, err
 		} else if rightContent, err := tree.Right.HashContent(); err != nil {
+			//@ fold acc(tree.InvRec(), 1/2)
+			//@ fold acc(tree.Inv(), 1/2)
 			return nil, err
 		} else {
-			hashContent = append( /*@ perm(1/2), @*/ []byte{0x02}, leftContent...)
-			return append( /*@ perm(1/2), @*/ hashContent, rightContent...), nil
+			//@ fold acc(tree.InvRec(), 1/2)
+			//@ fold acc(tree.Inv(), 1/2)
+			buf := make([]byte, 1+len(leftContent)+len(rightContent))
+			buf[0] = 0x02
+			_ = copy(buf[1:], leftContent /*@ , perm(1/2) @*/)
+			_ = copy(buf[1+len(leftContent):], rightContent /*@ , perm(1/2) @*/)
+			return buf, nil
 		}
 	}
 }
 
 // Recursively compute all hashes of a prefix tree.
-//@ requires tree != nil ==> tree.Inv()
-//@ ensures  tree != nil ==> tree.Inv()
-//@ ensures  tree != nil && err != nil ==> tree.GetValue() != nil && len(tree.GetValueArray()) == len(hash) && (forall i int :: { hash[i] } 0 <= i && i < len(hash) ==> (tree.GetValueArray())[i] == hash[i])
+// @ preserves acc(tree.Inv(), 1/2)
+// @ ensures  tree != nil && err == nil ==> tree.GetValue() != nil && len(tree.GetValueArray()) == len(hash) && (forall i int :: { hash[i] } 0 <= i && i < len(hash) ==> (tree.GetValueArray())[i] == hash[i])
 func (tree *PrefixTree) ComputeHash() (hash [sha256.Size]byte, err error) {
 	if tree == nil {
 		return [sha256.Size]byte{}, errors.New("cannot hash empty node")
-	} else if tree.Value != nil {
-		return *tree.Value, nil
-	} else if tree.Left == nil && tree.Right == nil {
-		if tree.Leaf == nil {
+	} else if /*@ unfolding acc(tree.Inv(), _) in unfolding acc(tree.InvRec(), _) in @*/ tree.Value != nil {
+		return /*@ unfolding acc(tree.Inv(), _) in unfolding acc(tree.InvRec(), _) in @*/ *tree.Value, nil
+	} else if /*@ unfolding acc(tree.Inv(), _) in unfolding acc(tree.InvRec(), _) in @*/ tree.Left == nil && tree.Right == nil {
+		if /*@ unfolding acc(tree.Inv(), _) in unfolding acc(tree.InvRec(), _) in @*/ tree.Leaf == nil {
 			return [sha256.Size]byte{}, errors.New("neither leaf nor value given for empty node")
 		} else {
 			// TODO: We would have to include length, too, to be compliant with TLS
 			// encoding, but not so important right now because inputs are
 			// fixed-length and this may get changed in the future
-			value /*@ @ @*/ := sha256.Sum256(append( /*@ perm(1/2), @*/ tree.Leaf.Vrf_output[:], tree.Leaf.Commitment[:]...) /*@, perm(1/2) @*/)
+			//@ unfold acc(tree.Inv(), 1/2)
+			//@ unfold acc(tree.InvRec(), 1/2)
+			buf := make([]byte, len(tree.Leaf.Vrf_output)+len(tree.Leaf.Commitment))
+			_ = copy(buf, tree.Leaf.Vrf_output[:] /*@ , perm(1/2) @*/)
+			_ = copy(buf[len(tree.Leaf.Vrf_output):], tree.Leaf.Commitment[:] /*@ , perm(1/2) @*/)
+			value /*@ @ @*/ := sha256.Sum256(buf /*@ , perm(1/2) @*/)
 			tree.Value = &value
+			//@ fold acc(tree.InvRec(), 1/2)
+			//@ fold acc(tree.Inv(), 1/2)
 			return value, nil
 		}
 	} else {

--- a/pkg/proofs/proofs.go
+++ b/pkg/proofs/proofs.go
@@ -73,8 +73,8 @@ type PrefixSearchResult struct {
 
 /*@
 pred (p PrefixSearchResult) Inv() {
-	(p.Result_type == Inclusion || p.Result_type == NonInclusionParent || p.Result_type == NonInclusionLeaf) &&
-	p.Result_type == NonInclusionLeaf ==> p.Leaf.Inv()
+    (p.Result_type == Inclusion || p.Result_type == NonInclusionParent || p.Result_type == NonInclusionLeaf) &&
+    (p.Result_type == NonInclusionLeaf ==> acc(p.Leaf) && acc(&(p.Leaf).Vrf_output) && acc(&(p.Leaf).Commitment))
 }
 @*/
 
@@ -115,16 +115,19 @@ type CompleteBinaryLadderStep struct {
 
 /*@
 pred (s *CompleteBinaryLadderStep) Inv() {
-    acc(s, _) &&
-		acc(&s.Step, _) &&
-			acc((&s.Step).Inv(), _) &&
-		acc(&s.Result, _) &&
-			acc((&s.Result).Inv(), _)
+    acc(s) &&
+        acc(&s.Step) &&
+            acc((&s.Step).Inv()) &&
+        acc(&s.Result) &&
+            acc((&s.Result).Inv()) &&
+        (s.Result.Result_type == NonInclusionLeaf ==> acc(s.Result.Leaf) && acc(&(s.Result.Leaf).Vrf_output) && acc(&(s.Result.Leaf).Commitment))
 }
 @*/
 
 // @ requires forall i int :: { steps[i] } 0 <= i && i < len(steps) ==> acc(&steps[i], 1/2)
 // @ ensures forall i int :: { completeSteps[i] } 0 <= i && i < len(completeSteps) ==> acc(&completeSteps[i]) && acc(completeSteps[i].Inv())
+// @ ensures forall i int :: { &completeSteps[i] } 0 <= i && i < len(completeSteps) ==> acc(&completeSteps[i], 1/2)
+// @ ensures forall i int :: { &completeSteps[i] } 0 <= i && i < len(completeSteps) ==> acc((&completeSteps[i]).Inv(), 1/2)
 func CombineResults(results []PrefixSearchResult, steps []BinaryLadderStep) (completeSteps []CompleteBinaryLadderStep, err error) {
 	completeSteps = make([]CompleteBinaryLadderStep, 0, len(results))
 	if len(steps) < len(results) {

--- a/pkg/proofs/proofs.go
+++ b/pkg/proofs/proofs.go
@@ -59,7 +59,9 @@ type PrefixLeaf struct {
 
 /*@
 pred (p *PrefixLeaf) Inv() {
-     acc(p)
+	acc(p) &&
+	acc(&p.Vrf_output) &&
+	acc(&p.Commitment)
 }
 @*/
 
@@ -81,6 +83,17 @@ type PrefixProof struct {
 	Elements []NodeValue
 }
 
+/*@
+pred (p PrefixProof) Inv() {
+	acc(p.Results, _) &&
+		(forall i int :: { p.Results[i] } 0 <= i && i < len(p.Elements) ==> acc(&p.Elements[i], _)) &&
+		(forall i, j int :: { &p.Results[i], &p.Results[j] } 0 <= i && i < len(p.Results) && 0 <= j && j < len(p.Results) && i != j ==> &p.Results[i] != &p.Results[j]) &&
+	acc(p.Elements, _) &&
+		(forall i int :: { p.Elements[i] } 0 <= i && i < len(p.Elements) ==> acc(&p.Elements[i], _)) &&
+		(forall i, j int :: { &p.Elements[i], &p.Elements[j] } 0 <= i && i < len(p.Elements) && 0 <= j && j < len(p.Elements) && i != j ==> &p.Elements[i] != &p.Elements[j])
+}
+@*/
+
 type CombinedTreeProof struct {
 	Timestamps    []uint64
 	Prefix_proofs []PrefixProof
@@ -100,7 +113,18 @@ type CompleteBinaryLadderStep struct {
 	Result PrefixSearchResult
 }
 
-//@ trusted
+/*@
+pred (s *CompleteBinaryLadderStep) Inv() {
+    acc(s, _) &&
+		acc(&s.Step, _) &&
+			acc((&s.Step).Inv(), _) &&
+		acc(&s.Result, _) &&
+			acc((&s.Result).Inv(), _)
+}
+@*/
+
+// @ requires forall i int :: { steps[i] } 0 <= i && i < len(steps) ==> acc(&steps[i], 1/2)
+// @ ensures forall i int :: { completeSteps[i] } 0 <= i && i < len(completeSteps) ==> acc(&completeSteps[i]) && acc(completeSteps[i].Inv())
 func CombineResults(results []PrefixSearchResult, steps []BinaryLadderStep) (completeSteps []CompleteBinaryLadderStep, err error) {
 	completeSteps = make([]CompleteBinaryLadderStep, 0, len(results))
 	if len(steps) < len(results) {
@@ -108,12 +132,12 @@ func CombineResults(results []PrefixSearchResult, steps []BinaryLadderStep) (com
 	}
 
 	sortedSteps := make([]BinaryLadderStep, 0, len(results))
-	copy(sortedSteps, steps[:len(results)])
+	copy(sortedSteps, steps[:len(results)] /*@, perm(1/2) @*/)
 	sortBinaryLadderSteps(sortedSteps)
 
 	for i, step := range sortedSteps {
-		completeSteps = append(completeSteps, CompleteBinaryLadderStep{
-			Step:   PrefixLeaf{
+		completeSteps = append( /*@ perm(1/2), @*/ completeSteps, CompleteBinaryLadderStep{
+			Step: PrefixLeaf{
 				Vrf_output: crypto.VRF_proof_to_hash(step.Proof),
 				Commitment: step.Commitment,
 			},
@@ -124,13 +148,12 @@ func CombineResults(results []PrefixSearchResult, steps []BinaryLadderStep) (com
 	return completeSteps, nil
 }
 
-//@ trusted
-//@ preserves acc(sortedSteps)
+// @ trusted
+// @ preserves acc(sortedSteps)
 func sortBinaryLadderSteps(sortedSteps []BinaryLadderStep) {
 	slices.SortFunc(sortedSteps, func(a, b BinaryLadderStep) int {
 		hashA := crypto.VRF_proof_to_hash(a.Proof)
 		hashB := crypto.VRF_proof_to_hash(b.Proof)
 		return bytes.Compare(hashA[:], hashB[:])
 	})
-	return
 }


### PR DESCRIPTION
This is very much work in progress, but I figured a pull request would make discussion and feedback easier.

I'm making liberal use of ChatGPT and various GitHub Copilot models as training wheels.


---

NB.  I have the SIF annotations removed locally so that the nightly Gobra release behind `gobra-ide` runs without `hyperGobra`:

```diff
diff --git a/pkg/prefixtree/prefixtree.go b/pkg/prefixtree/prefixtree.go
index 4a7c90f..0652631 100644
--- a/pkg/prefixtree/prefixtree.go
+++ b/pkg/prefixtree/prefixtree.go
@@ -179,12 +179,9 @@ pure func (n *Node) prefixSubtreeContains(prefix seq[bool], key uint64, value in
 
 // copath is sorted such that hashes for subtrees deeper in the prefix tree appear later in the slice
 //@ requires  noPerm < p
-//@ requires low(key)
-//@ requires low(rootHash)
 //@ preserves acc(copath, p)
 //@ preserves acc(n.PrefixTree(), p) && rootHash == n.prefixTreeHash()
 //@ ensures   res ==> n.prefixTreeContains(key, value)
-//@ ensures   res ==> low(value)
 func CheckInclusionWithoutTree(key uint64, value int, rootHash int, copath []int /*@, ghost n *Node, ghost p perm @*/) (res bool) {
 	if len(copath) != len(ComputeBits(key)) {
 		return false
@@ -226,11 +223,8 @@ pure func PureComputePath(i int, leafHash int, copath []int, keyBits seq[bool])
 ghost
 decreases
 requires noPerm < p && acc(copath, p)
-requires low(rootHash) && low(keyBits)
 requires IsValidCoPath(rootHash, leafHash, copath, keyBits)
 ensures  acc(copath, p)
-ensures  low(leafHash)
-ensures  forall j int :: { copath[j] } 0 <= j && j < len(copath) ==> low(copath[j])
 func IsValidCoPathInjective(rootHash, leafHash int, copath []int, keyBits seq[bool], p perm) {
     PureComputePathInjective(0, leafHash, copath, keyBits, p/2)
 }
@@ -241,12 +235,7 @@ requires noPerm < p && acc(copath, p)
 requires  0 <= i && i <= len(keyBits)
 requires leafHash != InexistentSubtreeHash
 requires len(copath) == len(keyBits)
-requires low(keyBits) && low(i)
-requires low(PureComputePath(i, leafHash, copath, keyBits))
 ensures  acc(copath, p)
-ensures  low(leafHash)
-// we learn more about the lowness of copath with each recursive invocation:
-ensures  forall j int :: { copath[j] } i <= j && j < len(copath) ==> low(copath[j])
 func PureComputePathInjective(i int, leafHash int, copath []int, keyBits seq[bool], p perm) {
     if i != len(keyBits) {
         pathPostfix := PureComputePath(i + 1, leafHash, copath, keyBits)
```