### PR TITLE
Refactors the `client` package

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -72,7 +72,6 @@ jobs:
       image: gobraverifier/gobra-base:v6_z3_4.8.7
     env:
       MOD_NAME: github.com/felixlinker/keytrans-verification
-      EXCLUDE_PKGS: "main"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -107,6 +106,7 @@ jobs:
     env:
       MOD_NAME: github.com/felixlinker/keytrans-verification
       EXCLUDE_PKGS: "main"
+      UNARY_MODE_PKGS: "proofs trees utils"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -130,7 +130,7 @@ jobs:
             --hyperMode off \
             --recursive \
             --include "." ".verification" \
-            --includePackages "proofs"
+            --includePackages ${{ env.UNARY_MODE_PKGS }}
 
       - name: Verify packages (with hyperMode)
         working-directory: keytrans-verification
@@ -140,7 +140,7 @@ jobs:
             --hyperMode extended \
             --recursive \
             --include "." ".verification" \
-            --excludePackages ${{ env.EXCLUDE_PKGS }} "proofs"
+            --excludePackages ${{ env.EXCLUDE_PKGS }} ${{ env.UNARY_MODE_PKGS }}
 
       - name: Upload Gobra statistics
         if: ${{ always() }}

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -20,7 +20,7 @@ jobs:
     env:
       MOD_NAME: github.com/felixlinker/keytrans-verification
       EXCLUDE_PKGS: "main"
-      UNARY_MODE_PKGS: "proofs trees utils"
+      UNARY_MODE_PKGS: "proofs utils"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.verification/math/const.gobra
+++ b/.verification/math/const.gobra
@@ -1,0 +1,5 @@
+package math
+
+// taken from https://cs.opensource.google/go/go/+/refs/tags/go1.26.2:src/math/const.go
+
+const MaxUint64 = 1<<64 - 1           // 18446744073709551615

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -35,104 +35,14 @@ import (
 // PrefixTreesInv encapsulates per-element permissions for prefix tree slices.
 // Reduces quantifier count in the SIF product program.
 pred PrefixTreesInv(trees []*prefixtree.PrefixTree) {
-		forall i int :: {&trees[i]} i >= 0 && i < len(trees) ==> acc(&trees[i]) && trees[i].Inv() && trees[i] != nil
+		forall i int :: { &trees[i] } 0 <= i && i < len(trees) ==> acc(&trees[i]) && trees[i].Inv() && trees[i] != nil
 }
 
 // RootHashesInv encapsulates per-element permissions for root hash slices.
 pred RootHashesInv(hashes []*[sha256.Size]byte) {
-	forall i int :: {&hashes[i]} i >= 0 && i < len(hashes) ==> acc(&hashes[i]) && acc(hashes[i])
-}
-
-ghost
-decreases
-pure func min(a, b uint64) uint64 {
-  return a < b ? a : b
-}
-
-ghost
-decreases
-pure func max(a, b uint64) uint64 {
-  return a > b ? a : b
-}
-
-// IsTStar captures: tStarVal == TStar(min(t1,t2), max(t1,t2))
-// AND min(t1,t2) < tStarVal <= max(t1,t2) if t1 != t2
-ghost
-decreases
-opaque
-pure func IsTStar(tStarVal, t1, t2 uint64) bool {
-  return (t1 < 0 || t2 < 0) ? true :  // Cannot happen for uint64, but needed as proof hint
-    t1 == t2 ? true :
-        tStarVal == TStarBetween(t1, t2)
-}
-
-ghost
-requires min(t1,t2) >= 0 && max(t1,t2) > 0
-ensures t1 != t2 ==> min(t1, t2) < res && res <= max(t1, t2)
-decreases
-pure func TStarBetween(t1, t2 uint64) (res uint64) {
-  return t1 == t2 ? 0 :
-    t1 < t2 ? proofs.TStar_pure(t1, t2) : proofs.TStar_pure(t2, t1)
-}
-
-// Build low ghost seq from a *[sha256.Size]byte array
-ghost
-requires acc(arr, 1/2)
-requires forall k int :: {arr[k]} 0 <= k && k < sha256.Size ==> low(arr[k])
-ensures acc(arr, 1/2)
-ensures low(result)
-decreases
-func buildLowSeqFromHash(arr *[sha256.Size]byte) (result seq[byte]) {
-  i := 0
-
-  invariant acc(arr, 1/2)
-  invariant 0 <= i && i <= sha256.Size
-  invariant low(i)
-  invariant low(result)
-  invariant forall k int :: {arr[k]} 0 <= k && k < sha256.Size ==> low(arr[k])
-  decreases sha256.Size - i
-  for i < sha256.Size {
-    result = result ++ seq[byte]{arr[i]}
-    i = i + 1
-  }
-}
-
-
-ghost
-requires n >= 0
-requires low(n)
-requires forall i int :: {&hashes[i]} 0 <= i && i < n ==> acc(&hashes[i]) && acc(hashes[i])
-requires forall i int :: {&hashes[i]} 0 <= i && i < n ==> forall k int :: {hashes[i][k]} 0 <= k && k < sha256.Size ==> low(hashes[i][k])
-ensures low(result)
-ensures len(result) == n
-ensures forall i int :: {&hashes[i]} 0 <= i && i < n ==> acc(&hashes[i]) && acc(hashes[i])
-decreases
-func buildRootHashContents(hashes []*[sha256.Size]byte, n int) (result seq[seq[byte]]) {
-  i := 0
-
-  invariant 0 <= i && i <= n
-  invariant low(i)
-  invariant low(n)
-  invariant low(result)
-  invariant len(result) == i
-  invariant forall j int :: {&hashes[j]} 0 <= j && j < n ==> acc(&hashes[j]) && acc(hashes[j])
-  invariant forall j int :: {&hashes[j]} 0 <= j && j < n ==> forall k int :: {hashes[j][k]} 0 <= k && k < sha256.Size ==> low(hashes[j][k])
-  decreases n - i
-  for i < n {
-    s := buildLowSeqFromHash(hashes[i])
-    result = result ++ seq[seq[byte]]{s}
-    i = i + 1
-  }
+	forall i int :: { &hashes[i] } 0 <= i && i < len(hashes) ==> acc(&hashes[i]) && acc(hashes[i])
 }
 @*/
-
-type PT interface {
-	// Returns non-nil if we can prove that the prefix tree contains a key for the
-	// label and version pair provided. Returns nil if we can prove that the
-	// prefix tree does not contain a key for the label and version pair provided.
-	// Returns error in any other case.
-	GetCommitment(Label []byte, Version uint64, RootHash []byte) (res []byte, err error)
-}
 
 type TreeHead struct {
 	Tree_size uint64
@@ -214,6 +124,7 @@ pred (s SearchResponse) Inv() {
 // @ requires low(len(resp.Search.Prefix_proofs))
 // @ ensures err != nil ==> acc(resp.Inv(), p)
 // @ ensures err == nil ==> acc(resp.Version, p) && low(*resp.Version)
+// @ trusted // TODO: remove once we can verify the entire function
 func (st *UserState) VerifyLatest(query SearchRequest, resp SearchResponse, config *Configuration /*@, ghost p perm @*/) (res *proofs.UpdateValue, err error) {
 	//@ unfold acc(resp.Inv(), p)
 	determined := false
@@ -362,6 +273,7 @@ func FullBinaryLadderSteps_with_tstar_alternative(target uint64) (r []uint64 /*@
 //	+1: a version above t is present (greater version exists)
 //
 // @ requires noPerm < p
+// @ requires prefixTree != nil
 // @ requires acc(prefixTree.Inv(), p)
 // @ requires acc(utils.BytesMem(label), p)
 // @ requires acc(utils.BytesMem(rootHash), p)
@@ -374,19 +286,18 @@ func FullBinaryLadderSteps_with_tstar_alternative(target uint64) (r []uint64 /*@
 // @ 	low(utils.getContent(rootHash)) ==>
 // @ 		low(t)
 // @ decreases
-func CheckGreatest(prefixTree *prefixtree.PrefixTree, label []byte, t uint64, rootHash []byte, size uint64 /*@, ghost p perm @*/) (res int, err error) {
-	steps /*@, tStarIdx @*/ := FullBinaryLadderSteps_with_tstar_alternative(t)
+func CheckGreatest(prefixTree prefixtree.PT, label []byte, t uint64, rootHash []byte, size uint64 /*@, ghost p perm @*/) (res int, err error) {
+	steps /*@, tStarIdx @*/ := FullBinaryLadderSteps_with_tstar(t)
 	//@ unfold proofs.BinaryLadderInv(steps)
 
 	determined := false // this flag encodes early returns, which are not yet supported by Gobra's hypermode
 	//@ tStar := steps[tStarIdx]
 
+	// after visiting `tStarIdx` and successfully passing all checks (i.e., `!determined`), one of the following two cases will hold.
+	// as desired, these two conditions are contradictory unless `low(t)` holds, which establishes the postcondition.
 	//@ labelSeq, rootHashSeq := utils.getContent(label), utils.getContent(rootHash)
 	//@ non_incl_expected :=  prefixtree.GetCommitmentExists(labelSeq, tStar, rootHashSeq) && tStar <= t
 	//@ incl_expected 	  := !prefixtree.GetCommitmentExists(labelSeq, tStar, rootHashSeq) &&     t  <  tStar
-
-	// after visiting `tStarIdx` and successfully passing all checks (i.e., `!determined`), one of the following two cases will hold.
-	// as desired, this contradicts `IsTStar(tStar, rel(t, 0), rel(t, 1))` unless `low(t)` holds, which establishes the postcondition.
 
 	//@ invariant acc(prefixTree.Inv(), p/2)
 	//@ invariant acc(utils.BytesMem(rootHash), p/2) && rootHashSeq == utils.getContent(rootHash)
@@ -454,6 +365,7 @@ type MonitoringMapEntry struct {
 // @ ensures acc(prefixTrees, p)
 // @ ensures acc(prefixRootHash, p)
 // @ ensures err == nil && res ==> low(*resp.Version)
+// @ trusted // TODO: remove once we can verify the entire function
 func VerifyLatestKey(prefixTrees []*prefixtree.PrefixTree, prefixRootHash []*[sha256.Size]byte, size uint64, query SearchRequest, resp SearchResponse, monitor_map []MonitoringMapEntry, config *Configuration /*@, ghost rootHashContents seq[seq[byte]], ghost p perm @*/) (res bool, err error) {
 	t := resp.Version //Claimed greatest version
 	tVal := uint64(*t)

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -34,8 +34,8 @@ import (
 /*@
 // PrefixTreesInv encapsulates per-element permissions for prefix tree slices.
 // Reduces quantifier count in the SIF product program.
-pred PrefixTreesInv(trees []*prefixtree.PrefixTree) {
-		forall i int :: { &trees[i] } 0 <= i && i < len(trees) ==> acc(&trees[i]) && trees[i].Inv() && trees[i] != nil
+pred PrefixTreesInv(trees []prefixtree.PT) {
+		forall i int :: { &trees[i] } 0 <= i && i < len(trees) ==> acc(&trees[i]) && trees[i] != nil && trees[i].Inv()
 }
 
 // RootHashesInv encapsulates per-element permissions for root hash slices.
@@ -167,7 +167,7 @@ func (st *UserState) VerifyLatest(query SearchRequest, resp SearchResponse, conf
 	n := len(resp.Search.Prefix_proofs)
 	//@ fold acc(resp.Inv(), p)
 
-	var trees []*prefixtree.PrefixTree
+	var trees []prefixtree.PT
 	var rootHashes []*[sha256.Size]byte
 	//@ ghost var rhContents seq[seq[byte]] = seq[seq[byte]]{}
 	if !determined {
@@ -342,39 +342,49 @@ type MonitoringMapEntry struct {
 }
 
 // @ requires noPerm < p
-// @ requires acc(config, p)
-// @ requires acc(monitor_map)
+// @ requires acc(PrefixTreesInv(prefixTrees), p)
+// @ requires acc(RootHashesInv(prefixRootHash), p)
+// @ requires 0 < size && size <= uint64(len(prefixTrees)) && size <= uint64(len(prefixRootHash))
+// query
 // @ requires acc(utils.BytesMem(query.Label), p)
 // @ requires query.Label != nil
-// requires low(len(query.Label)) && forall i int :: {query.Label[i]} 0 <= i && i < len(query.Label) ==> low(query.Label[i])
+// response
 // @ requires acc(resp.Version, p)
 // @ requires acc(utils.BytesMem(resp.Full_tree_head.RootHash), p)
 // @ requires resp.Version != nil
 // @ requires *resp.Version >= 0
 // @ requires resp.Full_tree_head.RootHash != nil
-// @ requires acc(PrefixTreesInv(prefixTrees), p)
-// @ requires acc(RootHashesInv(prefixRootHash), p)
-// @ requires size > 0 && size <= uint64(len(prefixTrees)) && size <= uint64(len(prefixRootHash))
-// @ requires len(rootHashContents) == len(prefixRootHash)
-// @ requires low(size)
-// @ requires low(rootHashContents)
-// @ ensures acc(config, p)
-// @ ensures acc(utils.BytesMem(query.Label), p)
-// @ ensures acc(resp.Version, p)
-// @ ensures resp.Full_tree_head.RootHash != nil ==> acc(utils.BytesMem(resp.Full_tree_head.RootHash), p)
-// @ ensures acc(prefixTrees, p)
-// @ ensures acc(prefixRootHash, p)
-// @ ensures err == nil && res ==> low(*resp.Version)
+// @ requires acc(monitorMap)
+// @ requires acc(config, p)
+// relational preconditions:
+// requires low(size)
+// requires low(len(query.Label)) && forall i int :: {query.Label[i]} 0 <= i && i < len(query.Label) ==> low(query.Label[i])
+// TODO remove:
+//
+//	requires len(rootHashContents) == len(prefixRootHash)
+//	requires low(rootHashContents)
+//
+// @ ensures  acc(PrefixTreesInv(prefixTrees), p)
+// @ ensures  acc(RootHashesInv(prefixRootHash), p)
+// @ ensures  acc(utils.BytesMem(query.Label), p)
+// @ ensures  acc(resp.Version, p)
+// @ ensures  acc(utils.BytesMem(resp.Full_tree_head.RootHash), p)
+// @ ensures  acc(monitorMap)
+// @ ensures  acc(config, p)
+// @ ensures err == nil && res &&
+// @	low(size) &&
+// @	low(rootHashContents) ==>
+// @		low(*resp.Version)
 // @ trusted // TODO: remove once we can verify the entire function
-func VerifyLatestKey(prefixTrees []*prefixtree.PrefixTree, prefixRootHash []*[sha256.Size]byte, size uint64, query SearchRequest, resp SearchResponse, monitor_map []MonitoringMapEntry, config *Configuration /*@, ghost rootHashContents seq[seq[byte]], ghost p perm @*/) (res bool, err error) {
+func VerifyLatestKey(prefixTrees []prefixtree.PT, prefixRootHash []*[sha256.Size]byte, size uint64, query SearchRequest, resp SearchResponse, monitorMap []MonitoringMapEntry, config *Configuration /*@, ghost rootHashContents seq[seq[byte]], ghost p perm @*/) (res bool, err error) {
 	t := resp.Version //Claimed greatest version
 	tVal := uint64(*t)
-	search_tree := MkImplicitBinarySearchTree(size)
+	searchTree := MkImplicitBinarySearchTree(size)
 	resultRes := true
 	var resultErr error = nil
-	frontiers := search_tree.FrontierNodes( /*@ p, size @*/ )
+	frontiers := searchTree.FrontierNodes( /*@ p @*/ )
 	terminalLogEntry := -1
-	determined := false
+	determined := false // encodes early returns
 
 	if size == 0 || tVal >= size {
 		resultRes = false
@@ -501,7 +511,7 @@ func VerifyLatestKey(prefixTrees []*prefixtree.PrefixTree, prefixRootHash []*[sh
 			Position: uint64(len(frontiers) - 1),
 			Version:  *t,
 		}
-		monitor_map = append( /*@ perm(1/2), @*/ monitor_map, entry)
+		monitorMap = append( /*@ perm(1/2), @*/ monitorMap, entry)
 	}
 
 	//@ unfold acc(PrefixTreesInv(prefixTrees), p)
@@ -520,8 +530,8 @@ func VerifyLatestKey(prefixTrees []*prefixtree.PrefixTree, prefixRootHash []*[sh
 // @ ensures err == nil ==> forall j int :: {&rootHashes[j]} 0 <= j && j < n ==> acc(&rootHashes[j]) && acc(rootHashes[j])
 // @ ensures err == nil ==> forall j int :: {&rootHashes[j]} 0 <= j && j < n ==> forall k int :: {rootHashes[j][k]} 0 <= k && k < sha256.Size ==> low(rootHashes[j][k])
 // @ trusted
-func buildPrefixTrees(resp SearchResponse, n int /*@, ghost p perm @*/) (trees []*prefixtree.PrefixTree, rootHashes []*[sha256.Size]byte, err error) {
-	trees = make([]*prefixtree.PrefixTree, 0, n)
+func buildPrefixTrees(resp SearchResponse, n int /*@, ghost p perm @*/) (trees []prefixtree.PT, rootHashes []*[sha256.Size]byte, err error) {
+	trees = make([]prefixtree.PT, 0, n)
 	rootHashes = make([]*[sha256.Size]byte, 0, n)
 	//@ unfold acc(resp.Inv(), p)
 	for i := 0; i < n; i++ {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -188,7 +188,7 @@ func (st *UserState) VerifyLatest(query SearchRequest, resp SearchResponse, conf
 	}
 
 	// Phase 4: VerifyLatestKey
-	decision := false
+	decision := false // TODO: remove
 	if !determined {
 		//@ unfold acc(resp.Inv(), p)
 		//@ unfold acc(resp.Full_tree_head.Inv(), p)
@@ -197,7 +197,8 @@ func (st *UserState) VerifyLatest(query SearchRequest, resp SearchResponse, conf
 		//@ assert len(trees) == n && len(rootHashes) == n
 		monitoringMap := make([]*MonitoringMapEntry, 0)
 		var entry *MonitoringMapEntry
-		decision, entry, err = VerifyLatestKey(trees, rootHashes, query, resp, config /*@, rhContents, p @*/)
+		entry, err = VerifyLatestKey(trees, rootHashes, query, resp, config /*@, rhContents, p @*/)
+		decision = err == nil
 		//@ unfold acc(query.Inv(), p)
 		if entry != nil {
 			monitoringMap = append( /*@ perm(1/2), @*/ monitoringMap, entry)
@@ -362,29 +363,25 @@ type MonitoringMapEntry struct {
 // @ ensures   acc(resp.Inv(), p)
 // @ ensures   err == nil && entry != nil ==> acc(entry)
 // hyper-postcondition:
-// @ ensures   err == nil && res &&
+// @ ensures   err == nil &&
 // @	low(len(prefixTrees)) && low(query.LabelContent()) &&
 // @	low(GetRootHashContent(prefixRootHash, len(prefixTrees)-1)) ==>
 // @		unfolding acc(resp.Inv(), p) in low(*resp.Version)
 // @ decreases
-// returns a non-nil map entry if an entry needs to be monitored
-func VerifyLatestKey(prefixTrees []prefixtree.PT, prefixRootHash []*[sha256.Size]byte, query SearchRequest, resp SearchResponse, monitorMap []MonitoringMapEntry, config *Configuration /*@, ghost p perm @*/) (res bool, entry *MonitoringMapEntry, err error) {
+// returns an error if verification fails and a non-nil map entry if an entry needs to be monitored
+func VerifyLatestKey(prefixTrees []prefixtree.PT, prefixRootHash []*[sha256.Size]byte, query SearchRequest, resp SearchResponse, monitorMap []MonitoringMapEntry, config *Configuration /*@, ghost p perm @*/) (entry *MonitoringMapEntry, err error) {
 	size := uint64(len(prefixTrees))
 	t := /*@ unfolding acc(resp.Inv(), p) in @*/ uint64(*resp.Version) // claimed greatest version
 	searchTree := MkImplicitBinarySearchTree(uint64(len(prefixTrees)))
 	frontiers := searchTree.FrontierNodes( /*@ 1/2 @*/ )
 	terminalLogEntry := -1
-	// flag encoding early termination:
-	determined := false
 
-	// TODO use res and err instead
-	resultRes := true
-	var resultErr error = nil
-	if size == 0 || size <= t {
-		resultRes = false
-		resultErr = errors.New("version out of bounds")
-		determined = true
+	if size <= t {
+		err = errors.New("version out of bounds")
 	}
+
+	// we use `err` to skip loop iterations instead of
+	// returning early, which is not yet supported by Gobra's hypermode.
 
 	//@ invariant noPerm < p
 	//@ invariant acc(PrefixTreesInv(prefixTrees), p/2)
@@ -395,11 +392,9 @@ func VerifyLatestKey(prefixTrees []prefixtree.PT, prefixRootHash []*[sha256.Size
 	//@ invariant 0 <= fIdx && fIdx <= len(frontiers)
 	//@ invariant -1 <= terminalLogEntry && terminalLogEntry < len(prefixTrees)
 	//@ invariant forall i int :: { frontiers[i] } 0 <= i && i < len(frontiers) ==> 0 <= frontiers[i] && frontiers[i] < uint64(len(prefixTrees))
-	//@ invariant determined ==> !resultRes
-	//@ invariant !determined ==> resultRes && resultErr == nil
 	// hyper-invariants:
 	//@ invariant low(size) ==> low(fIdx)
-	//@ invariant low(size) && fIdx == len(frontiers) && !determined &&
+	//@ invariant low(size) && fIdx == len(frontiers) && err == nil &&
 	//@ 	low(query.LabelContent()) &&
 	//@ 	low(GetRootHashContent(prefixRootHash, int(frontiers[fIdx - 1]))) ==>
 	//@			low(t)
@@ -409,34 +404,26 @@ func VerifyLatestKey(prefixTrees []prefixtree.PT, prefixRootHash []*[sha256.Size
 	//@ decreases len(frontiers) - fIdx
 	for fIdx := 0; fIdx < len(frontiers); fIdx++ {
 		frontier := frontiers[fIdx]
-		if !determined {
+		if err == nil {
 			//@ unfold acc(PrefixTreesInv(prefixTrees), p/4)
 			prefixTree := prefixTrees[frontier]
 			//@ unfold acc(RootHashesInv(prefixRootHash), p/4)
 			rootHash := prefixRootHash[frontier][:]
 			if frontier >= size {
-				resultRes = false
-				resultErr = errors.New("version out of bounds")
-				determined = true
+				err = errors.New("version out of bounds")
 			}
-			if !determined {
+			if err == nil {
 				//@ unfold acc(query.Inv(), p/4)
 				LtGtOrEq, cgErr := CheckGreatest(prefixTree, query.Label, t, rootHash, size /*@, p/8 @*/)
 				//@ fold acc(query.Inv(), p/4)
 				if cgErr != nil {
-					resultRes = false
-					resultErr = cgErr
-					determined = true
+					err = cgErr
 				} else if LtGtOrEq == 1 {
-					resultRes = false
-					resultErr = errors.New("greater version exists")
-					determined = true
+					err = errors.New("greater version exists")
 				} else if LtGtOrEq == -1 && fIdx == len(frontiers)-1 {
 					// last frontier node for which we expect
 					// a zero result. Anything else is an error
-					resultRes = false
-					resultErr = errors.New("Greatest version is not the greatest in the last iteration")
-					determined = true
+					err = errors.New("Greatest version is not the greatest in the last iteration")
 				} else if LtGtOrEq == 0 && terminalLogEntry == -1 {
 					// we found a frontier node that has `t` as
 					// the greatest version
@@ -448,9 +435,8 @@ func VerifyLatestKey(prefixTrees []prefixtree.PT, prefixRootHash []*[sha256.Size
 		}
 	}
 
-	if terminalLogEntry == -1 && resultErr == nil {
-		resultRes = false
-		resultErr = errors.New("Claimed Version is not found.")
+	if terminalLogEntry == -1 && err == nil {
+		err = errors.New("Claimed Version is not found.")
 	}
 	if frontiers[0] < uint64(terminalLogEntry) && config.Mode == 1 {
 		entry = &MonitoringMapEntry{
@@ -458,8 +444,7 @@ func VerifyLatestKey(prefixTrees []prefixtree.PT, prefixRootHash []*[sha256.Size
 			Version:  uint32(t),
 		}
 	}
-
-	return resultRes, entry, resultErr
+	return
 }
 
 // buildPrefixTrees constructs prefix trees from the response's prefix proofs.

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -337,7 +337,8 @@ func VerifyLatestKey(prefixTrees []prefixtree.PT, prefixRootHash []*[sha256.Size
 	t := /*@ unfolding acc(resp.Inv(), p) in @*/ uint64(*resp.Version) // claimed greatest version
 	searchTree := MkImplicitBinarySearchTree(uint64(len(prefixTrees)))
 	frontiers := searchTree.FrontierNodes( /*@ 1/2 @*/ )
-	terminalLogEntry := -1
+	terminalLogEntryFound := false
+	var terminalLogEntry uint64
 
 	if size <= t {
 		err = errors.New("version out of bounds")
@@ -353,7 +354,7 @@ func VerifyLatestKey(prefixTrees []prefixtree.PT, prefixRootHash []*[sha256.Size
 	//@ invariant acc(query.Inv(), p/2)
 	//@ invariant acc(resp.Inv(), p/2)
 	//@ invariant 0 <= fIdx && fIdx <= len(frontiers)
-	//@ invariant -1 <= terminalLogEntry && terminalLogEntry < len(prefixTrees)
+	//@ invariant terminalLogEntryFound ==> 0 <= terminalLogEntry && terminalLogEntry < uint64(len(prefixTrees))
 	//@ invariant forall i int :: { frontiers[i] } 0 <= i && i < len(frontiers) ==> 0 <= frontiers[i] && frontiers[i] < uint64(len(prefixTrees))
 	// hyper-invariants:
 	//@ invariant low(size) ==> low(fIdx)
@@ -361,9 +362,10 @@ func VerifyLatestKey(prefixTrees []prefixtree.PT, prefixRootHash []*[sha256.Size
 	//@ 	low(query.LabelContent()) &&
 	//@ 	low(GetRootHashContent(prefixRootHash, int(frontiers[fIdx - 1]))) ==>
 	//@			low(t)
-	// note that `terminalLogEntry` might get set in different loop iterations
-	// such that we do not obtain any hyper properties about it as CheckGreatest
-	// provides information about `t` only if _both_ executions return 0.
+	// note that `terminalLogEntry` might get set in different loop iterations in
+	// the two executions, such that we do not obtain any hyper properties about it
+	// as CheckGreatest provides information about `t` only if _both_ executions
+	// return 0.
 	//@ decreases len(frontiers) - fIdx
 	for fIdx := 0; fIdx < len(frontiers); fIdx++ {
 		frontier := frontiers[fIdx]
@@ -387,10 +389,11 @@ func VerifyLatestKey(prefixTrees []prefixtree.PT, prefixRootHash []*[sha256.Size
 					// last frontier node for which we expect
 					// a zero result. Anything else is an error
 					err = errors.New("Greatest version is not the greatest in the last iteration")
-				} else if LtGtOrEq == 0 && terminalLogEntry == -1 {
+				} else if LtGtOrEq == 0 && !terminalLogEntryFound {
 					// we found a frontier node that has `t` as
 					// the greatest version
-					terminalLogEntry = int(frontier)
+					terminalLogEntryFound = true
+					terminalLogEntry = frontier
 				}
 			}
 			//@ fold acc(RootHashesInv(prefixRootHash), p/4)
@@ -398,10 +401,10 @@ func VerifyLatestKey(prefixTrees []prefixtree.PT, prefixRootHash []*[sha256.Size
 		}
 	}
 
-	if terminalLogEntry == -1 && err == nil {
+	if err == nil && !terminalLogEntryFound {
 		err = errors.New("Claimed Version is not found.")
 	}
-	if frontiers[0] < uint64(terminalLogEntry) && config.Mode == 1 {
+	if err == nil && frontiers[0] < terminalLogEntry && config.Mode == 1 {
 		entry = &MonitoringMapEntry{
 			Position: uint64(len(frontiers) - 1),
 			Version:  uint32(t),

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -40,7 +40,15 @@ pred PrefixTreesInv(trees []prefixtree.PT) {
 
 // RootHashesInv encapsulates per-element permissions for root hash slices.
 pred RootHashesInv(hashes []*[sha256.Size]byte) {
-	forall i int :: { &hashes[i] } 0 <= i && i < len(hashes) ==> acc(&hashes[i]) && acc(hashes[i])
+	forall i int :: { hashes[i] } 0 <= i && i < len(hashes) ==> acc(&hashes[i]) && utils.BytesMem(hashes[i][:])
+}
+
+ghost
+requires acc(RootHashesInv(hashes), _)
+requires 0 <= idx && idx < len(hashes)
+decreases
+pure func GetRootHashContent(hashes []*[sha256.Size]byte, idx int) seq[byte] {
+	return unfolding acc(RootHashesInv(hashes), _) in utils.getContent(hashes[idx][:])
 }
 @*/
 
@@ -63,7 +71,7 @@ type FullTreeHead struct {
 
 /*@
 pred (f FullTreeHead) Inv() {
-	f.Tree_head.Inv() && acc(f.RootHash)
+	f.Tree_head.Inv() && utils.BytesMem(f.RootHash)
 }
 
 ghost
@@ -82,7 +90,14 @@ type SearchRequest struct {
 
 /*@
 pred (s SearchRequest) Inv() {
-	acc(s.Last) && acc(s.Label)
+	acc(s.Last) && utils.BytesMem(s.Label)
+}
+
+ghost
+requires acc(s.Inv(), _)
+decreases
+pure func (s SearchRequest) LabelContent() seq[byte] {
+	return unfolding acc(s.Inv(), _) in utils.getContent(s.Label)
 }
 @*/
 
@@ -99,7 +114,9 @@ type SearchResponse struct {
 /*@
 pred (s SearchResponse) Inv() {
 	s.Full_tree_head.Inv() &&
-	(s.Version != nil ==> acc(s.Version)) &&
+	// `0 <= s.Version` holds trivially but Gobra currently
+	// does not infer this property
+	(s.Version != nil ==> acc(s.Version) && 0 <= *s.Version) &&
 	acc(s.Binary_ladder) &&
 	s.Search.Inv() &&
 	s.Inclusion.Inv() &&
@@ -113,7 +130,7 @@ pred (s SearchResponse) Inv() {
 // @ requires acc(config, p)
 // @ requires acc(query.Inv(), p)
 // @ requires unfolding acc(query.Inv(), p) in query.Label != nil
-// @ requires unfolding acc(query.Inv(), p) in low(len(query.Label)) && forall i int :: { query.Label[i] } 0 <= i && i < len(query.Label) ==> low(query.Label[i])
+// @ requires low(query.LabelContent())
 // @ requires acc(resp.Inv(), p)
 // @ requires resp.Version != nil
 // @ requires unfolding acc(resp.Inv(), p) in *resp.Version >= 0
@@ -126,34 +143,24 @@ pred (s SearchResponse) Inv() {
 // @ ensures err == nil ==> acc(resp.Version, p) && low(*resp.Version)
 // @ trusted // TODO: remove once we can verify the entire function
 func (st *UserState) VerifyLatest(query SearchRequest, resp SearchResponse, config *Configuration /*@, ghost p perm @*/) (res *proofs.UpdateValue, err error) {
-	//@ unfold acc(resp.Inv(), p)
+	// flag encoding early termination
 	determined := false
 
 	// Phase 1: UpdateView
-	updateErr := st.UpdateView(resp.Full_tree_head, resp.Search /*@, p/2 @*/)
-	if updateErr != nil {
-		err = updateErr
+	//@ unfold acc(resp.Inv(), p)
+	err = st.UpdateView(resp.Full_tree_head, resp.Search /*@, p/2 @*/)
+	if err != nil {
 		determined = true
 	}
 
 	// Phase 2: Validation checks (resp.Inv() still unfolded)
-	if !determined {
-		if resp.Version == nil {
-			err = errors.New("no version provided")
-			determined = true
-		}
+	if !determined && resp.Version == nil {
+		err = errors.New("no version provided")
+		determined = true
 	}
-	if !determined {
-		if *resp.Version < 0 {
-			err = errors.New("Version is negative")
-			determined = true
-		}
-	}
-	if !determined {
-		if len(resp.Search.Prefix_roots) != 0 {
-			err = errors.New("prefix roots provided")
-			determined = true
-		}
+	if !determined && len(resp.Search.Prefix_roots) != 0 {
+		err = errors.New("prefix roots provided")
+		determined = true
 	}
 	if !determined {
 		ladderIndices /*@, idx @*/ := proofs.FullBinaryLadderSteps(uint64(*resp.Version) /*@, 0 @*/)
@@ -171,13 +178,11 @@ func (st *UserState) VerifyLatest(query SearchRequest, resp SearchResponse, conf
 	var rootHashes []*[sha256.Size]byte
 	//@ ghost var rhContents seq[seq[byte]] = seq[seq[byte]]{}
 	if !determined {
-		var buildErr error
-		trees, rootHashes, buildErr = buildPrefixTrees(resp, n /*@, p @*/)
-		if buildErr != nil {
-			err = buildErr
+		trees, rootHashes, err = buildPrefixTrees(resp, n /*@, p @*/)
+		if err != nil {
 			determined = true
 		} else {
-			//@ rhContents = buildRootHashContents(rootHashes, n)
+			//@ rhContents = utilsrel.buildRootHashContents(rootHashes, n)
 			//@ fold acc(RootHashesInv(rootHashes), p)
 		}
 	}
@@ -187,10 +192,16 @@ func (st *UserState) VerifyLatest(query SearchRequest, resp SearchResponse, conf
 	if !determined {
 		//@ unfold acc(resp.Inv(), p)
 		//@ unfold acc(resp.Full_tree_head.Inv(), p)
-		//@ unfold acc(query.Inv(), p)
 		size := resp.Full_tree_head.Tree_head.Tree_size
-		monitoringMap := make([]MonitoringMapEntry, 0)
-		decision, err = VerifyLatestKey(trees, rootHashes, size, query, resp, monitoringMap, config /*@, rhContents, p @*/)
+		//@ assert size <= n
+		//@ assert len(trees) == n && len(rootHashes) == n
+		monitoringMap := make([]*MonitoringMapEntry, 0)
+		var entry *MonitoringMapEntry
+		decision, entry, err = VerifyLatestKey(trees, rootHashes, query, resp, config /*@, rhContents, p @*/)
+		//@ unfold acc(query.Inv(), p)
+		if entry != nil {
+			monitoringMap = append( /*@ perm(1/2), @*/ monitoringMap, entry)
+		}
 
 		if !decision || err != nil {
 			//@ fold acc(resp.Full_tree_head.Inv(), p)
@@ -272,16 +283,14 @@ func FullBinaryLadderSteps_with_tstar_alternative(target uint64) (r []uint64 /*@
 //	 0: all steps are consistent (t is the greatest version)
 //	+1: a version above t is present (greater version exists)
 //
-// @ requires noPerm < p
-// @ requires prefixTree != nil
-// @ requires acc(prefixTree.Inv(), p)
-// @ requires acc(utils.BytesMem(label), p)
-// @ requires acc(utils.BytesMem(rootHash), p)
-// @ requires 0 <= t
-// @ ensures acc(prefixTree.Inv(), p)
-// @ ensures acc(utils.BytesMem(label), p)
-// @ ensures acc(utils.BytesMem(rootHash), p)
-// @ ensures err == nil && res == 0 &&
+// @ requires  noPerm < p
+// @ requires  prefixTree != nil
+// @ preserves acc(prefixTree.Inv(), p)
+// @ preserves acc(utils.BytesMem(label), p)
+// @ preserves acc(utils.BytesMem(rootHash), p)
+// @ requires  0 <= t
+// @ ensures   err == nil ==> -1 <= res && res <= 1
+// @ ensures   err == nil && res == 0 &&
 // @ 	low(utils.getContent(label)) &&
 // @ 	low(utils.getContent(rootHash)) ==>
 // @ 		low(t)
@@ -308,6 +317,7 @@ func CheckGreatest(prefixTree prefixtree.PT, label []byte, t uint64, rootHash []
 	//@ invariant 0 <= tStarIdx && tStarIdx < len(steps)
 	//@ invariant tStar == steps[tStarIdx]
 	//@ invariant determined != (res == 0 && err == nil)
+	//@ invariant err == nil ==> -1 <= res && res <= 1
 	//@ invariant tStarIdx < idx && !determined ==> non_incl_expected || incl_expected
 	//@ decreases len(steps) - idx
 	for idx := 0; idx < len(steps); idx++ {
@@ -341,164 +351,100 @@ type MonitoringMapEntry struct {
 	Version  uint32
 }
 
-// @ requires noPerm < p
-// @ requires acc(PrefixTreesInv(prefixTrees), p)
-// @ requires acc(RootHashesInv(prefixRootHash), p)
-// @ requires 0 < size && size <= uint64(len(prefixTrees)) && size <= uint64(len(prefixRootHash))
-// query
-// @ requires acc(utils.BytesMem(query.Label), p)
-// @ requires query.Label != nil
-// response
-// @ requires acc(resp.Version, p)
-// @ requires acc(utils.BytesMem(resp.Full_tree_head.RootHash), p)
-// @ requires resp.Version != nil
-// @ requires *resp.Version >= 0
-// @ requires resp.Full_tree_head.RootHash != nil
-// @ requires acc(monitorMap)
-// @ requires acc(config, p)
-// relational preconditions:
-// requires low(size)
-// requires low(len(query.Label)) && forall i int :: {query.Label[i]} 0 <= i && i < len(query.Label) ==> low(query.Label[i])
-// TODO remove:
-//
-//	requires len(rootHashContents) == len(prefixRootHash)
-//	requires low(rootHashContents)
-//
-// @ ensures  acc(PrefixTreesInv(prefixTrees), p)
-// @ ensures  acc(RootHashesInv(prefixRootHash), p)
-// @ ensures  acc(utils.BytesMem(query.Label), p)
-// @ ensures  acc(resp.Version, p)
-// @ ensures  acc(utils.BytesMem(resp.Full_tree_head.RootHash), p)
-// @ ensures  acc(monitorMap)
-// @ ensures  acc(config, p)
-// @ ensures err == nil && res &&
-// @	low(size) &&
-// @	low(rootHashContents) ==>
-// @		low(*resp.Version)
-// @ trusted // TODO: remove once we can verify the entire function
-func VerifyLatestKey(prefixTrees []prefixtree.PT, prefixRootHash []*[sha256.Size]byte, size uint64, query SearchRequest, resp SearchResponse, monitorMap []MonitoringMapEntry, config *Configuration /*@, ghost rootHashContents seq[seq[byte]], ghost p perm @*/) (res bool, err error) {
-	t := resp.Version //Claimed greatest version
-	tVal := uint64(*t)
-	searchTree := MkImplicitBinarySearchTree(size)
+// @ requires  noPerm < p
+// @ preserves acc(PrefixTreesInv(prefixTrees), p)
+// @ preserves acc(RootHashesInv(prefixRootHash), p)
+// @ requires  0 < len(prefixTrees) && len(prefixTrees) == len(prefixRootHash)
+// @ preserves acc(query.Inv(), p)
+// @ requires  acc(resp.Inv(), p)
+// @ requires  unfolding acc(resp.Inv(), p) in resp.Version != nil
+// @ preserves acc(config, p)
+// @ ensures   acc(resp.Inv(), p)
+// @ ensures   err == nil && entry != nil ==> acc(entry)
+// hyper-postcondition:
+// @ ensures   err == nil && res &&
+// @	low(len(prefixTrees)) && low(query.LabelContent()) &&
+// @	low(GetRootHashContent(prefixRootHash, len(prefixTrees)-1)) ==>
+// @		unfolding acc(resp.Inv(), p) in low(*resp.Version)
+// @ decreases
+// returns a non-nil map entry if an entry needs to be monitored
+func VerifyLatestKey(prefixTrees []prefixtree.PT, prefixRootHash []*[sha256.Size]byte, query SearchRequest, resp SearchResponse, monitorMap []MonitoringMapEntry, config *Configuration /*@, ghost p perm @*/) (res bool, entry *MonitoringMapEntry, err error) {
+	size := uint64(len(prefixTrees))
+	t := /*@ unfolding acc(resp.Inv(), p) in @*/ uint64(*resp.Version) // claimed greatest version
+	searchTree := MkImplicitBinarySearchTree(uint64(len(prefixTrees)))
+	frontiers := searchTree.FrontierNodes( /*@ 1/2 @*/ )
+	terminalLogEntry := -1
+	// flag encoding early termination:
+	determined := false
+
+	// TODO use res and err instead
 	resultRes := true
 	var resultErr error = nil
-	frontiers := searchTree.FrontierNodes( /*@ p @*/ )
-	terminalLogEntry := -1
-	determined := false // encodes early returns
-
-	if size == 0 || tVal >= size {
+	if size == 0 || size <= t {
 		resultRes = false
 		resultErr = errors.New("version out of bounds")
 		determined = true
 	}
 
-	// Loop: process all frontiers except the last
-	// labelSeq := utilsrel.getContentIsLow(query.Label, p)
-
-	//@ invariant acc(PrefixTreesInv(prefixTrees), p)
-	//@ invariant acc(RootHashesInv(prefixRootHash), p)
-	//@ invariant acc(frontiers)
-	//@ invariant acc(resp.Version, p)
-	//@ invariant acc(utils.BytesMem(resp.Full_tree_head.RootHash), p)
-	//@ invariant acc(utils.BytesMem(query.Label), p)
-	//@ invariant acc(config, p)
-	//@ invariant tVal == uint64(*t)
-	//@ invariant tVal >= 0
-	//@ invariant 0 <= fIdx && fIdx <= len(frontiers) - 1
-	//@ invariant len(frontiers) > 0
-	//@ invariant len(rootHashContents) == len(prefixRootHash)
-	//@ invariant forall i int :: {frontiers[i]} i >= 0 && i < len(frontiers) ==> frontiers[i]>=0 && frontiers[i] < uint64(len(prefixTrees))
-	//@ invariant forall i int :: {frontiers[i]} i >= 0 && i < len(frontiers) ==> frontiers[i]>=0 && frontiers[i] < uint64(len(prefixRootHash))
+	//@ invariant noPerm < p
+	//@ invariant acc(PrefixTreesInv(prefixTrees), p/2)
+	//@ invariant acc(RootHashesInv(prefixRootHash), p/2)
+	//@ invariant acc(frontiers, 1/2)
+	//@ invariant acc(query.Inv(), p/2)
+	//@ invariant acc(resp.Inv(), p/2)
+	//@ invariant 0 <= fIdx && fIdx <= len(frontiers)
+	//@ invariant -1 <= terminalLogEntry && terminalLogEntry < len(prefixTrees)
+	//@ invariant forall i int :: { frontiers[i] } 0 <= i && i < len(frontiers) ==> 0 <= frontiers[i] && frontiers[i] < uint64(len(prefixTrees))
 	//@ invariant determined ==> !resultRes
 	//@ invariant !determined ==> resultRes && resultErr == nil
-	//@ invariant low(fIdx)
-	//@ invariant low(size)
-	// invariant low(labelSeq)
-	//@ invariant low(rootHashContents)
-	//@ invariant low(len(frontiers)) && forall j int :: {frontiers[j]} j>= 0 && j < len(frontiers) ==> low(frontiers[j])
-	for fIdx := 0; fIdx < len(frontiers)-1; fIdx++ {
+	// hyper-invariants:
+	//@ invariant low(size) ==> low(fIdx)
+	//@ invariant low(size) && fIdx == len(frontiers) && !determined &&
+	//@ 	low(query.LabelContent()) &&
+	//@ 	low(GetRootHashContent(prefixRootHash, int(frontiers[fIdx - 1]))) ==>
+	//@			low(t)
+	// note that `terminalLogEntry` might get set in different loop iterations
+	// such that we do not obtain any hyper properties about it as CheckGreatest
+	// provides information about `t` only if _both_ executions return 0.
+	//@ decreases len(frontiers) - fIdx
+	for fIdx := 0; fIdx < len(frontiers); fIdx++ {
 		frontier := frontiers[fIdx]
 		if !determined {
-			//@ assert frontier >= 0 && int(frontier) < len(prefixTrees)
-			//@ unfold acc(PrefixTreesInv(prefixTrees), p)
-			//@ unfold acc(RootHashesInv(prefixRootHash), p)
-			Prefix_tree := prefixTrees[frontier]
-			if prefixTrees[frontier] == nil {
-				//@ fold acc(PrefixTreesInv(prefixTrees), p)
-				//@ fold acc(RootHashesInv(prefixRootHash), p)
-				resultRes = false
-				resultErr = errors.New("prefix tree is nil")
-				determined = true
-			} else {
-				rootHash := prefixRootHash[frontier][:]
-				if frontier >= size {
-					//@ fold acc(PrefixTreesInv(prefixTrees), p)
-					//@ fold acc(RootHashesInv(prefixRootHash), p)
-					resultRes = false
-					resultErr = errors.New("version out of bounds")
-					determined = true
-				}
-				if !determined {
-					//@ fold acc(utils.BytesMem(rootHash), p)
-					LtGtOrEq, cgErr := CheckGreatest(Prefix_tree, query.Label, tVal, rootHash, size /*@, p @*/)
-					//@ unfold acc(utils.BytesMem(rootHash), p)
-					//@ fold acc(PrefixTreesInv(prefixTrees), p)
-					//@ fold acc(RootHashesInv(prefixRootHash), p)
-					if cgErr != nil {
-						resultRes = false
-						resultErr = cgErr
-						determined = true
-					} else if LtGtOrEq == 1 {
-						resultRes = false
-						resultErr = errors.New("greater version exists")
-						determined = true
-					} else if LtGtOrEq == 0 && terminalLogEntry == -1 {
-						terminalLogEntry = int(frontier)
-					}
-				}
-			}
-		}
-	}
-
-	// Process last frontier separately
-	if !determined {
-		//@ unfold acc(PrefixTreesInv(prefixTrees), p)
-		//@ unfold acc(RootHashesInv(prefixRootHash), p)
-		frontier := frontiers[len(frontiers)-1]
-		Prefix_tree := prefixTrees[frontier]
-		if prefixTrees[frontier] == nil {
-			//@ fold acc(PrefixTreesInv(prefixTrees), p)
-			//@ fold acc(RootHashesInv(prefixRootHash), p)
-			resultRes = false
-			resultErr = errors.New("prefix tree is nil")
-			determined = true
-		} else {
+			//@ unfold acc(PrefixTreesInv(prefixTrees), p/4)
+			prefixTree := prefixTrees[frontier]
+			//@ unfold acc(RootHashesInv(prefixRootHash), p/4)
 			rootHash := prefixRootHash[frontier][:]
 			if frontier >= size {
-				//@ fold acc(PrefixTreesInv(prefixTrees), p)
-				//@ fold acc(RootHashesInv(prefixRootHash), p)
 				resultRes = false
 				resultErr = errors.New("version out of bounds")
 				determined = true
 			}
 			if !determined {
-				//@ fold acc(utils.BytesMem(rootHash), p)
-				LtGtOrEq, cgErr := CheckGreatest(Prefix_tree, query.Label, tVal, rootHash, size /*@, p @*/)
-				//@ unfold acc(utils.BytesMem(rootHash), p)
-				//@ fold acc(PrefixTreesInv(prefixTrees), p)
-				//@ fold acc(RootHashesInv(prefixRootHash), p)
+				//@ unfold acc(query.Inv(), p/4)
+				LtGtOrEq, cgErr := CheckGreatest(prefixTree, query.Label, t, rootHash, size /*@, p/8 @*/)
+				//@ fold acc(query.Inv(), p/4)
 				if cgErr != nil {
 					resultRes = false
 					resultErr = cgErr
 					determined = true
-				} else if LtGtOrEq != 0 {
+				} else if LtGtOrEq == 1 {
+					resultRes = false
+					resultErr = errors.New("greater version exists")
+					determined = true
+				} else if LtGtOrEq == -1 && fIdx == len(frontiers)-1 {
+					// last frontier node for which we expect
+					// a zero result. Anything else is an error
 					resultRes = false
 					resultErr = errors.New("Greatest version is not the greatest in the last iteration")
 					determined = true
-				} else if terminalLogEntry == -1 {
+				} else if LtGtOrEq == 0 && terminalLogEntry == -1 {
+					// we found a frontier node that has `t` as
+					// the greatest version
 					terminalLogEntry = int(frontier)
 				}
 			}
+			//@ fold acc(RootHashesInv(prefixRootHash), p/4)
+			//@ fold acc(PrefixTreesInv(prefixTrees), p/4)
 		}
 	}
 
@@ -507,16 +453,13 @@ func VerifyLatestKey(prefixTrees []prefixtree.PT, prefixRootHash []*[sha256.Size
 		resultErr = errors.New("Claimed Version is not found.")
 	}
 	if frontiers[0] < uint64(terminalLogEntry) && config.Mode == 1 {
-		entry := MonitoringMapEntry{
+		entry = &MonitoringMapEntry{
 			Position: uint64(len(frontiers) - 1),
-			Version:  *t,
+			Version:  uint32(t),
 		}
-		monitorMap = append( /*@ perm(1/2), @*/ monitorMap, entry)
 	}
 
-	//@ unfold acc(PrefixTreesInv(prefixTrees), p)
-	//@ unfold acc(RootHashesInv(prefixRootHash), p)
-	return resultRes, resultErr
+	return resultRes, entry, resultErr
 }
 
 // buildPrefixTrees constructs prefix trees from the response's prefix proofs.

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -4,6 +4,8 @@ import (
 	"crypto/sha256"
 	"errors"
 
+	//@ "math"
+
 	//@ "github.com/felixlinker/keytrans-verification/pkg/arb"
 	"github.com/felixlinker/keytrans-verification/pkg/prefixtree"
 	"github.com/felixlinker/keytrans-verification/pkg/proofs"
@@ -318,7 +320,8 @@ type MonitoringMapEntry struct {
 // @ requires  noPerm < p
 // @ preserves acc(PrefixTreesInv(prefixTrees), p)
 // @ preserves acc(RootHashesInv(prefixRootHash), p)
-// @ requires  0 < len(prefixTrees) && len(prefixTrees) == len(prefixRootHash)
+// @ requires  0 < len(prefixTrees) && len(prefixTrees) <= math.MaxUint64
+// @ requires  len(prefixTrees) == len(prefixRootHash)
 // @ preserves acc(query.Inv(), p)
 // @ requires  acc(resp.Inv(), p)
 // @ requires  unfolding acc(resp.Inv(), p) in resp.Version != nil
@@ -421,7 +424,7 @@ func VerifyLatestKey(prefixTrees []prefixtree.PT, prefixRootHash []*[sha256.Size
 // ensures   resp.Version != nil ==> (unfolding acc(resp.Inv(), p) in *resp.Version >= 0)
 // @ ensures   err == nil ==> len(trees) == unfolding acc(resp.Inv(), p) in len(resp.Search.Prefix_proofs)
 // @ ensures   err == nil ==> acc(PrefixTreesInv(trees), p)
-// @ ensures   err == nil ==> len(rootHashes) == len(trees)
+// @ ensures   err == nil ==> len(rootHashes) == len(trees) && len(trees) <= math.MaxUint64
 // @ ensures   err == nil ==> RootHashesInv(rootHashes)
 // ensures err == nil ==> forall j int :: {&rootHashes[j]} 0 <= j && j < n ==> forall k int :: {rootHashes[j][k]} 0 <= k && k < sha256.Size ==> low(rootHashes[j][k])
 // hyper-postcondition expressing that this function checks correctness of the root hashes:

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -40,7 +40,7 @@ pred PrefixTreesInv(trees []prefixtree.PT) {
 
 // RootHashesInv encapsulates per-element permissions for root hash slices.
 pred RootHashesInv(hashes []*[sha256.Size]byte) {
-	forall i int :: { hashes[i] } 0 <= i && i < len(hashes) ==> acc(&hashes[i]) && utils.BytesMem(hashes[i][:])
+	forall i int :: { &hashes[i] } 0 <= i && i < len(hashes) ==> acc(&hashes[i]) && utils.BytesMem(hashes[i][:])
 }
 
 ghost

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -125,107 +125,70 @@ pred (s SearchResponse) Inv() {
 }
 @*/
 
-// @ requires noPerm < p
+// @ requires  noPerm < p
 // @ preserves st.Inv()
-// @ requires acc(config, p)
-// @ requires acc(query.Inv(), p)
-// @ requires unfolding acc(query.Inv(), p) in query.Label != nil
-// @ requires low(query.LabelContent())
-// @ requires acc(resp.Inv(), p)
-// @ requires resp.Version != nil
-// @ requires unfolding acc(resp.Inv(), p) in *resp.Version >= 0
-// @ requires resp.Full_tree_head.RootHash != nil
-// @ requires resp.Full_tree_head.Tree_head.Tree_size > 0
-// @ requires resp.Full_tree_head.Tree_head.Tree_size <= uint64(len(resp.Search.Prefix_proofs))
-// @ requires low(resp.Full_tree_head.Tree_head.Tree_size)
-// @ requires low(len(resp.Search.Prefix_proofs))
-// @ ensures err != nil ==> acc(resp.Inv(), p)
-// @ ensures err == nil ==> acc(resp.Version, p) && low(*resp.Version)
-// @ trusted // TODO: remove once we can verify the entire function
+// @ preserves acc(config, p)
+// @ preserves acc(query.Inv(), p)
+// @ requires  acc(resp.Inv(), p)
+// @ requires  unfolding acc(resp.Inv(), p) in 0 < len(resp.Search.Prefix_proofs)
+// @ ensures   acc(resp.Inv(), p)
+// @ ensures   err == nil ==> acc(res) && res.Inv()
+// hyper-postcondition:
+// @ ensures   err == nil &&
+// @	low(query.LabelContent()) &&
+// @ 	(unfolding acc(resp.Inv(), p) in low(resp.Full_tree_head.Tree_head.Tree_size) && low(len(resp.Search.Prefix_proofs))) ==>
+// @		unfolding acc(resp.Inv(), p) in resp.Version != nil && low(*resp.Version)
 func (st *UserState) VerifyLatest(query SearchRequest, resp SearchResponse, config *Configuration /*@, ghost p perm @*/) (res *proofs.UpdateValue, err error) {
-	// flag encoding early termination
-	determined := false
+	// we use `err` to skip later phases instead of returning early, which is not yet supported by Gobra's hypermode.
 
 	// Phase 1: UpdateView
 	//@ unfold acc(resp.Inv(), p)
 	err = st.UpdateView(resp.Full_tree_head, resp.Search /*@, p/2 @*/)
-	if err != nil {
-		determined = true
-	}
 
 	// Phase 2: Validation checks (resp.Inv() still unfolded)
-	if !determined && resp.Version == nil {
+	if err == nil && resp.Version == nil {
 		err = errors.New("no version provided")
-		determined = true
 	}
-	if !determined && len(resp.Search.Prefix_roots) != 0 {
-		err = errors.New("prefix roots provided")
-		determined = true
+	if err == nil && len(resp.Search.Prefix_roots) == 0 {
+		err = errors.New("no prefix roots provided")
 	}
-	if !determined {
+	if err == nil {
 		ladderIndices /*@, idx @*/ := proofs.FullBinaryLadderSteps(uint64(*resp.Version) /*@, 0 @*/)
 		if len(resp.Binary_ladder) != len(ladderIndices) {
 			err = errors.New("length of binary ladder does not match greatest version")
-			determined = true
 		}
 	}
-
-	// Phase 3: Build prefix trees
-	n := len(resp.Search.Prefix_proofs)
 	//@ fold acc(resp.Inv(), p)
 
+	// Phase 3: Build prefix trees
 	var trees []prefixtree.PT
 	var rootHashes []*[sha256.Size]byte
-	//@ ghost var rhContents seq[seq[byte]] = seq[seq[byte]]{}
-	if !determined {
-		trees, rootHashes, err = buildPrefixTrees(resp, n /*@, p @*/)
-		if err != nil {
-			determined = true
-		} else {
-			//@ rhContents = utilsrel.buildRootHashContents(rootHashes, n)
-			//@ fold acc(RootHashesInv(rootHashes), p)
-		}
+	if err == nil {
+		trees, rootHashes, err = buildPrefixTrees(resp /*@, p @*/)
 	}
 
 	// Phase 4: VerifyLatestKey
-	decision := false // TODO: remove
-	if !determined {
-		//@ unfold acc(resp.Inv(), p)
-		//@ unfold acc(resp.Full_tree_head.Inv(), p)
-		size := resp.Full_tree_head.Tree_head.Tree_size
-		//@ assert size <= n
-		//@ assert len(trees) == n && len(rootHashes) == n
+	if err == nil {
 		monitoringMap := make([]*MonitoringMapEntry, 0)
 		var entry *MonitoringMapEntry
-		entry, err = VerifyLatestKey(trees, rootHashes, query, resp, config /*@, rhContents, p @*/)
-		decision = err == nil
-		//@ unfold acc(query.Inv(), p)
-		if entry != nil {
+		entry, err = VerifyLatestKey(trees, rootHashes, query, resp, config /*@, p/2 @*/)
+		if err == nil && entry != nil {
 			monitoringMap = append( /*@ perm(1/2), @*/ monitoringMap, entry)
-		}
-
-		if !decision || err != nil {
-			//@ fold acc(resp.Full_tree_head.Inv(), p)
-			//@ fold acc(resp.Inv(), p)
-			if err == nil {
-				err = errors.New("Query response does not contain latest version")
-			}
-			determined = true
 		}
 	}
 
 	// Phase 5: Single return
-	if !determined && decision {
-		// VerifyLatestKey ensures: err == nil && res ==> low(*resp.Version)
-		// Don't fold resp.Inv() — keep acc(resp.Version, p) for postcondition
-		//@ unfold acc(resp.Value.Inv(), p)
-		res = &proofs.UpdateValue{Value: resp.Value.Value}
-		//@ fold acc(resp.Value.Inv(), p)
-		err = nil
-	} else {
-		res = nil
+	if err == nil {
+		//@ unfold acc(resp.Inv(), p/2)
+		value := make([]byte, len(resp.Value.Value))
+		//@ unfold acc(resp.Value.Inv(), p/2)
+		copy(value, resp.Value.Value /*@, p/2 @*/)
+		//@ fold acc(resp.Value.Inv(), p/2)
+		//@ fold acc(resp.Inv(), p/2)
+		res = &proofs.UpdateValue{Value: value}
+		//@ fold res.Inv()
 	}
-	return res, err
+	return
 }
 
 // returns the full binary ladder together with tstar for the targets of the two
@@ -369,7 +332,7 @@ type MonitoringMapEntry struct {
 // @		unfolding acc(resp.Inv(), p) in low(*resp.Version)
 // @ decreases
 // returns an error if verification fails and a non-nil map entry if an entry needs to be monitored
-func VerifyLatestKey(prefixTrees []prefixtree.PT, prefixRootHash []*[sha256.Size]byte, query SearchRequest, resp SearchResponse, monitorMap []MonitoringMapEntry, config *Configuration /*@, ghost p perm @*/) (entry *MonitoringMapEntry, err error) {
+func VerifyLatestKey(prefixTrees []prefixtree.PT, prefixRootHash []*[sha256.Size]byte, query SearchRequest, resp SearchResponse, config *Configuration /*@, ghost p perm @*/) (entry *MonitoringMapEntry, err error) {
 	size := uint64(len(prefixTrees))
 	t := /*@ unfolding acc(resp.Inv(), p) in @*/ uint64(*resp.Version) // claimed greatest version
 	searchTree := MkImplicitBinarySearchTree(uint64(len(prefixTrees)))
@@ -448,20 +411,27 @@ func VerifyLatestKey(prefixTrees []prefixtree.PT, prefixRootHash []*[sha256.Size
 }
 
 // buildPrefixTrees constructs prefix trees from the response's prefix proofs.
-// @ requires noPerm < p
-// @ requires acc(resp.Inv(), p)
-// @ ensures acc(resp.Inv(), p)
-// @ ensures resp.Version != nil ==> (unfolding acc(resp.Inv(), p) in *resp.Version >= 0)
-// @ ensures err == nil ==> len(trees) == n
-// @ ensures err == nil ==> acc(PrefixTreesInv(trees), p)
-// @ ensures err == nil ==> len(rootHashes) == n
-// @ ensures err == nil ==> forall j int :: {&rootHashes[j]} 0 <= j && j < n ==> acc(&rootHashes[j]) && acc(rootHashes[j])
-// @ ensures err == nil ==> forall j int :: {&rootHashes[j]} 0 <= j && j < n ==> forall k int :: {rootHashes[j][k]} 0 <= k && k < sha256.Size ==> low(rootHashes[j][k])
+// @ requires  noPerm < p
+// @ requires  acc(resp.Inv(), p)
+// @ requires  unfolding acc(resp.Inv(), p) in 0 < len(resp.Search.Prefix_proofs)
+// @ ensures   acc(resp.Inv(), p)
+// ensures   resp.Version != nil ==> (unfolding acc(resp.Inv(), p) in *resp.Version >= 0)
+// @ ensures   err == nil ==> len(trees) == unfolding acc(resp.Inv(), p) in len(resp.Search.Prefix_proofs)
+// @ ensures   err == nil ==> acc(PrefixTreesInv(trees), p)
+// @ ensures   err == nil ==> len(rootHashes) == len(trees)
+// @ ensures   err == nil ==> RootHashesInv(rootHashes)
+// ensures err == nil ==> forall j int :: {&rootHashes[j]} 0 <= j && j < n ==> forall k int :: {rootHashes[j][k]} 0 <= k && k < sha256.Size ==> low(rootHashes[j][k])
+// hyper-postcondition expressing that this function checks correctness of the root hashes:
+// @ ensures err == nil &&
+// @ 	(unfolding acc(resp.Inv(), p) in low(len(resp.Search.Prefix_proofs))) ==>
+// @ 		low(GetRootHashContent(rootHashes, len(rootHashes)-1))
 // @ trusted
-func buildPrefixTrees(resp SearchResponse, n int /*@, ghost p perm @*/) (trees []prefixtree.PT, rootHashes []*[sha256.Size]byte, err error) {
+// TODO: this spec might not be fully correct yet!
+func buildPrefixTrees(resp SearchResponse /*@, ghost p perm @*/) (trees []prefixtree.PT, rootHashes []*[sha256.Size]byte, err error) {
+	//@ unfold acc(resp.Inv(), p)
+	n := len(resp.Search.Prefix_proofs)
 	trees = make([]prefixtree.PT, 0, n)
 	rootHashes = make([]*[sha256.Size]byte, 0, n)
-	//@ unfold acc(resp.Inv(), p)
 	for i := 0; i < n; i++ {
 		prf := /*@ unfolding acc(resp.Search.Inv(), p/2) in @*/ resp.Search.Prefix_proofs[i]
 		if tree, treeErr := prefixtree.ToTree(prf, resp.Binary_ladder); treeErr != nil {

--- a/pkg/client/treeview.go
+++ b/pkg/client/treeview.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"errors"
+	"math"
 
 	"github.com/felixlinker/keytrans-verification/pkg/proofs"
 	//@ "github.com/felixlinker/keytrans-verification/pkg/utils"
@@ -64,7 +65,7 @@ pure func (n *ImplicitBinarySearchNode) sizeRec(min, max uint64) (res int) {
 }
 @*/
 
-// @ requires 0 <= treeSize
+// @ requires 0 <= treeSize && treeSize <= math.MaxUint64
 // @ ensures  0 <= root
 // @ ensures  1 < treeSize ==> root < treeSize
 // @ ensures  root == RootNodePure(treeSize)
@@ -75,25 +76,32 @@ func RootNode(treeSize uint64) (root uint64) {
 	if treeSize >= 1 {
 		var power uint64 = 1
 		var prev uint64 = 1
+		overflowed := false
 		//@ ghost var i uint64 = 0
 
 		//@ invariant 0 <= i
+		//@ invariant overflowed ==> 0 < i && treeSize < 2*power
 		//@ invariant prev - 1 < treeSize
-		//@ invariant 1 <= power && 1 <= prev
-		//@ invariant power == utils.PowOf2_pure(i)
+		//@ invariant 1 <= power && power <= math.MaxUint64
+		//@ invariant 1 <= prev && prev <= math.MaxUint64
+		//@ invariant power == utils.PowOf2_pure(overflowed ? i-1 : i)
 		//@ invariant prev == (i == 0 ? 1 : utils.PowOf2_pure(i - 1))
-		//@ invariant utils.Log2Floor_pure(power) == i
+		//@ invariant utils.Log2Floor_pure(power) == (overflowed ? i-1 : i)
 		//@ invariant utils.Log2Floor_pure(prev) == (i == 0 ? 0 : i - 1)
 		//@ invariant prev <= treeSize
-		//@ invariant low(treeSize) ==> low(power) && low(prev)
+		//@ invariant low(treeSize) ==> low(power) && low(prev) && low(overflowed)
 		//@ decreases treeSize - power
-		for power-1 < treeSize {
+		for power-1 < treeSize && !overflowed {
 			prev = power
-			power = power * 2
+			if power > math.MaxUint64/2 {
+				overflowed = true
+			} else {
+				power = power * 2
+			}
 			//@ i++
 		}
 
-		//@ utils.Log2FloorInbetween(i - 1, prev, treeSize, power)
+		//@ utils.Log2FloorInbetween(i - 1, prev, treeSize, overflowed ? power*2 : power)
 		res = prev - 1
 	}
 	return res
@@ -197,34 +205,41 @@ func (node *ImplicitBinarySearchNode) frontierNodes( /*@ ghost min, max uint64, 
 	return
 }
 
-// @ requires 0 <= treeSize
+// @ requires 0 <= treeSize && treeSize <= math.MaxUint64
 // @ ensures  tree.Inv() && tree.Size() == treeSize
 // @ decreases
 func MkImplicitBinarySearchTree(treeSize uint64) (tree *ImplicitBinarySearchTree) {
-	root := mkImplicitBinarySearchNode(0, treeSize-1)
+	var root *ImplicitBinarySearchNode
+	if treeSize != 0 {
+		root = mkImplicitBinarySearchNode(0, treeSize-1)
+	}
 	tree = &ImplicitBinarySearchTree{treeSize, root}
 	//@ fold tree.Inv()
 	return
 }
 
-// @ requires 0 <= min && min <= max + 1
-// @ ensures  (min <= max) == (node != nil)
-// @ ensures  node != nil ==> node.Inv(min, max)
-// @ ensures  node != nil ==> uint64(node.Size(min, max)) == max - min + 1
+// @ requires  0 <= min && min <= max && max + 1 <= math.MaxUint64
+// @ ensures   node != nil
+// @ ensures   node.Inv(min, max)
+// @ ensures   uint64(node.Size(min, max)) == max - min + 1
 // @ decreases max - min
 func mkImplicitBinarySearchNode(min, max uint64) (node *ImplicitBinarySearchNode) {
+	root := RootNode(max+1-min) + min
 	if min == max { // treeSize == 1
-		root := RootNode(max-min+1) + min
 		node = &ImplicitBinarySearchNode{root, nil, nil}
 		//@ fold node.Inv(min, max)
-	} else if min < max {
-		root := RootNode(max-min+1) + min
-		left := mkImplicitBinarySearchNode(min, root-1)
-		right := mkImplicitBinarySearchNode(root+1, max)
+	} else { // min < max
+		var left *ImplicitBinarySearchNode
+		if root != min {
+			left = mkImplicitBinarySearchNode(min, root-1)
+		}
+		var right *ImplicitBinarySearchNode
+		if root != max {
+			right = mkImplicitBinarySearchNode(root+1, max)
+		}
 		node = &ImplicitBinarySearchNode{root, left, right}
 		//@ fold node.Inv(min, max)
 	}
-	// else: min == max+1 and node == nil
 	return
 }
 

--- a/pkg/client/treeview.go
+++ b/pkg/client/treeview.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 
 	"github.com/felixlinker/keytrans-verification/pkg/proofs"
+	//@ "github.com/felixlinker/keytrans-verification/pkg/utils"
 )
 
 // This file implements Section 4, "Updating Views of the Tree"
@@ -16,41 +17,95 @@ type ImplicitBinarySearchTree struct {
 
 /*@
 pred (t *ImplicitBinarySearchTree) Inv() {
-	acc(t) &&
+	acc(t) && 0 <= t.Root &&
 	(t.Left != nil ==> t.Left.Inv()) &&
-	(t.Right != nil ==> t.Right.Inv())
+	(t.Right != nil ==> t.Right.Inv()) &&
+	// valid ranges:
+	(t.Left != nil ==> t.Left.Max() < t.Root) &&
+	(t.Right != nil ==> t.Root < t.Right.Min())
 }
 
-
-//TODO
+ghost
+requires t != nil ==> acc(t.Inv(), _)
+ensures  0 <= res
 decreases
-//requires acc(tree.Inv(), _)
-pure func (tree *ImplicitBinarySearchTree) IsLow() bool
+pure func (t *ImplicitBinarySearchTree) Size() (res int) {
+	return t == nil ? 0 : t.sizeRec()
+}
+
+ghost
+requires acc(t.Inv(), _)
+ensures  0 <= res
+decreases acc(t.Inv(), _)
+pure func (t *ImplicitBinarySearchTree) sizeRec() (res int) {
+	return unfolding acc(t.Inv(), _) in 1 + (t.Left == nil ? 0 : t.Left.sizeRec()) + (t.Right == nil ? 0 : t.Right.sizeRec())
+}
+
+ghost
+requires acc(t.Inv(), _)
+ensures  0 <= res && res <= t.Max()
+decreases acc(t.Inv(), _)
+pure func (t *ImplicitBinarySearchTree) Min() (res uint64) {
+	return unfolding acc(t.Inv(), _) in t.Left == nil ? t.Root : t.Left.Min()
+}
+
+ghost
+requires acc(t.Inv(), _)
+decreases acc(t.Inv(), _)
+pure func (t *ImplicitBinarySearchTree) Max() uint64 {
+	return unfolding acc(t.Inv(), _) in t.Right == nil ? t.Root : t.Right.Max()
+}
 @*/
 
-// @ requires tree_size >= 0
-// @ requires low(tree_size)
-// @ ensures root >= 0
-// @ ensures tree_size >1 ==> root < tree_size
-// @ ensures low(root)
-func RootNode(tree_size uint64) (root uint64) {
+// @ requires 0 <= treeSize
+// @ ensures  0 <= root
+// @ ensures  1 < treeSize ==> root < treeSize
+// @ ensures  root == RootNodePure(treeSize)
+// @ ensures  low(treeSize) ==> low(root)
+// @ decreases
+func RootNode(treeSize uint64) (root uint64) {
 	var res uint64 = 0
-	if tree_size >= 1 {
+	if treeSize >= 1 {
 		var power uint64 = 1
 		var prev uint64 = 1
-		//@ invariant low(power) && low(tree_size) && low(prev)
-		//@ invariant prev - 1 < tree_size
-		//@ invariant power >=1 && prev >=1
-		for power-1 < tree_size {
+		//@ ghost var i uint64 = 0
+
+		//@ invariant 0 <= i
+		//@ invariant prev - 1 < treeSize
+		//@ invariant 1 <= power && 1 <= prev
+		//@ invariant power == utils.PowOf2_pure(i)
+		//@ invariant prev == (i == 0 ? 1 : utils.PowOf2_pure(i - 1))
+		//@ invariant utils.Log2Floor_pure(power) == i
+		//@ invariant utils.Log2Floor_pure(prev) == (i == 0 ? 0 : i - 1)
+		//@ invariant prev <= treeSize
+		//@ invariant low(treeSize) ==> low(power) && low(prev)
+		//@ decreases treeSize - power
+		for power-1 < treeSize {
 			prev = power
 			power = power * 2
+			//@ i++
 		}
+
+		//@ utils.Log2FloorInbetween(i - 1, prev, treeSize, power)
 		res = prev - 1
 	}
 	return res
 }
 
-// @ preserves tree!= nil ==> tree.Inv()
+/*@
+ghost
+decreases treeSize
+pure func RootNodePure(treeSize uint64) (root uint64) {
+	return treeSize == 0 ? 0 : utils.PowOf2_pure(utils.Log2Floor_pure(treeSize)) - 1
+}
+@*/
+
+// @ preserves tree != nil ==> tree.Inv()
+// @ requires  0 <= offset
+// @ ensures   old(tree.Size()) == tree.Size()
+// @ ensures   tree != nil ==> old(tree.Min()) + offset == tree.Min()
+// @ ensures   tree != nil ==> old(tree.Max()) + offset == tree.Max()
+// @ decreases tree.Size()
 func (tree *ImplicitBinarySearchTree) OffSet(offset uint64) {
 	if tree != nil {
 		//@ unfold tree.Inv()
@@ -131,59 +186,51 @@ func (tree *ImplicitBinarySearchTree) PathTo(node uint64 /*@, ghost p perm @*/) 
 //		return
 //	}
 //
-// TODO: analyse if we need to have full permissions if we incooperate with low or can we use partial permission.
 // @ requires  noPerm < p
-// @ requires tree != nil ==> tree.Inv()
-// @ requires tree == nil ==> low(tree)
-// @ requires tree!= nil ==> unfolding tree.Inv() in low(tree.Root)
-// @ ensures tree != nil ==> tree.Inv()
-// @ ensures tree!= nil ==> unfolding tree.Inv() in low(tree.Root)
+// @ preserves tree != nil ==> acc(tree.Inv(), p)
 // @ ensures   acc(path)
-// @ ensures   tree != nil ==> len(path) > 0
-// @ ensures forall j int :: j >= 0 && j < len(path) ==> path[j] >= 0 && path[j] < bound
-// @ ensures (low(len(path)) && forall i int :: 0<= i && i< len(path) ==>  low(path[i]))
-// @ trusted
-func (tree *ImplicitBinarySearchTree) FrontierNodes( /*@ ghost p perm, ghost bound uint64 @*/ ) (path []uint64) {
+// @ ensures   (tree == nil) == (0 == len(path))
+// @ ensures   tree != nil ==> forall j int :: { path[j] } 0 <= j && j < len(path) ==> tree.Min() <= path[j] && path[j] <= tree.Max()
+// ensures   tree != nil ==> unfolding acc(tree.Inv(), p) in low(tree.Root) ==> (low(len(path)) && forall i int :: { path[i] } 0 <= i && i < len(path) ==> low(path[i]))
+// @ decreases tree.Size()
+func (tree *ImplicitBinarySearchTree) FrontierNodes( /*@ ghost p perm @*/ ) (path []uint64) {
 	if tree != nil {
-		//@ unfold tree.Inv()
+		//@ unfold acc(tree.Inv(), p/2)
 		path = []uint64{tree.Root}
 		//@ assert low(len(path))
-		//@ assert forall j int :: j>= 0 && j < len(path) ==> low(path[j])
-		//@ assert tree.Right == nil ==> low(tree.Right)
-		//@ assert tree.Right != nil ==> unfolding tree.Right.Inv() in low(tree.Right.Root)
-		subtreePath := tree.Right.FrontierNodes( /*@ p, bound @*/ )
-		//@ assert low(len(subtreePath))
-		//@ assert forall j int :: j>= 0 && j < len(subtreePath) ==> low(subtreePath[j])
-		path = append( /*@ p, @*/ path, subtreePath...)
-		//@ assert low(len(path))
-		//@ assert forall j int :: j>= 0 && j < len(path) ==> low(path[j])
-		//@ fold tree.Inv()
+		//@ assert forall j int :: { path[j] } 0 <= j && j < len(path) && low(tree.Root) ==> low(path[j])
+		// assert tree.Right == nil ==> low(tree.Right)
+		// assert tree.Right != nil ==> unfolding tree.Right.Inv() in low(tree.Right.Root)
+		subtreePath := tree.Right.FrontierNodes( /*@ p/4 @*/ )
+		// assert low(len(subtreePath))
+		// assert forall j int :: 0 <= j && j < len(subtreePath) ==> low(subtreePath[j])
+		path = append( /*@ perm(1/2), @*/ path, subtreePath...)
+		// assert low(len(path))
+		// assert forall j int :: 0 <= j && j < len(path) ==> low(path[j])
+		//@ fold acc(tree.Inv(), p/2)
 	}
 	return
 }
 
-// @ requires tree_size >= 0
-// @ requires low(tree_size)
-// @ ensures tree_size == 0 ==> tree == nil
-// @ ensures tree_size != 0 ==> tree != nil
-// @ ensures tree != nil ==> tree.Inv()
-// @ ensures tree == nil ==> low(tree)
-// @ ensures tree != nil ==> unfolding tree.Inv() in low(tree.Root)
-func MkImplicitBinarySearchTree(tree_size uint64) (tree *ImplicitBinarySearchTree) {
-	if tree_size == 0 {
+// @ requires 0 <= treeSize
+// @ ensures  tree != nil ==> tree.Inv() && tree.Min() == 0 && tree.Max() == treeSize - 1
+// @ ensures  treeSize == uint64(tree.Size())
+// @ ensures  (treeSize == 0) == (tree == nil)
+// @ ensures  tree != nil ==> unfolding tree.Inv() in low(treeSize) ==> low(tree.Root)
+// @ decreases treeSize
+func MkImplicitBinarySearchTree(treeSize uint64) (tree *ImplicitBinarySearchTree) {
+	if treeSize == 0 {
 		tree = nil
-	} else if tree_size == 1 {
-		root := RootNode(tree_size)
+	} else if treeSize == 1 {
+		root := RootNode(treeSize)
 		tree = &ImplicitBinarySearchTree{root, nil, nil}
 		//@ fold tree.Inv()
-	} else if tree_size > 1 {
-		root := RootNode(tree_size)
+		//@ assert tree.Size() == 1
+	} else if treeSize > 1 {
+		root := RootNode(treeSize)
 		left := MkImplicitBinarySearchTree(root)
-		right := MkImplicitBinarySearchTree(tree_size - root - 1)
-
-		if right != nil {
-			right.OffSet(root + 1)
-		}
+		right := MkImplicitBinarySearchTree(treeSize - root - 1)
+		right.OffSet(root + 1)
 		tree = &ImplicitBinarySearchTree{root, left, right}
 		//@ fold tree.Inv()
 	}
@@ -258,8 +305,8 @@ func (st *UserState) UpdateView(new_head FullTreeHead, prf proofs.CombinedTreePr
 
 	oldSearchTree := MkImplicitBinarySearchTree(st.Size)
 	newSearchTree := MkImplicitBinarySearchTree(new_head.Tree_head.Tree_size)
-	oldFrontier := oldSearchTree.FrontierNodes( /*@ 1/2, st.Size @*/ )
-	newFrontier := newSearchTree.FrontierNodes( /*@ 1/2, new_head.Tree_head.Tree_size @*/ )
+	oldFrontier := oldSearchTree.FrontierNodes( /*@ 1/2 @*/ )
+	newFrontier := newSearchTree.FrontierNodes( /*@ 1/2 @*/ )
 
 	if st.Size == 0 {
 		// copy timestamps from `prf`:

--- a/pkg/client/treeview.go
+++ b/pkg/client/treeview.go
@@ -8,52 +8,59 @@ import (
 )
 
 // This file implements Section 4, "Updating Views of the Tree"
-
 type ImplicitBinarySearchTree struct {
-	Root  uint64
-	Left  *ImplicitBinarySearchTree
-	Right *ImplicitBinarySearchTree
+	size uint64
+	tree *ImplicitBinarySearchNode
 }
 
 /*@
 pred (t *ImplicitBinarySearchTree) Inv() {
-	acc(t) && 0 <= t.Root &&
-	(t.Left != nil ==> t.Left.Inv()) &&
-	(t.Right != nil ==> t.Right.Inv()) &&
-	// valid ranges:
-	(t.Left != nil ==> t.Left.Max() < t.Root) &&
-	(t.Right != nil ==> t.Root < t.Right.Min())
+	acc(t) && 0 <= t.size &&
+	((t.tree == nil) == (t.size == 0)) &&
+	(t.tree != nil ==>
+		t.tree.Inv(0, t.size - 1) &&
+		t.size == uint64(t.tree.Size(0, t.size - 1)))
 }
 
 ghost
-requires t != nil ==> acc(t.Inv(), _)
+requires acc(t.Inv(), _)
 ensures  0 <= res
 decreases
-pure func (t *ImplicitBinarySearchTree) Size() (res int) {
-	return t == nil ? 0 : t.sizeRec()
+pure func (t *ImplicitBinarySearchTree) Size() (res uint64) {
+	return unfolding acc(t.Inv(), _) in t.size
+}
+@*/
+
+type ImplicitBinarySearchNode struct {
+	Root  uint64
+	Left  *ImplicitBinarySearchNode
+	Right *ImplicitBinarySearchNode
+}
+
+/*@
+pred (n *ImplicitBinarySearchNode) Inv(min, max uint64) {
+	acc(n) && n.Root == RootNodePure(max + 1 - min) + min &&
+	min <= n.Root && n.Root <= max &&
+	((n.Left == nil) == (n.Root == min)) &&
+	(n.Left != nil ==> n.Left.Inv(min, n.Root - 1)) &&
+	((n.Right == nil) == (n.Root == max)) &&
+	(n.Right != nil ==> n.Right.Inv(n.Root + 1, max))
 }
 
 ghost
-requires acc(t.Inv(), _)
+requires n != nil ==> acc(n.Inv(min, max), _)
 ensures  0 <= res
-decreases acc(t.Inv(), _)
-pure func (t *ImplicitBinarySearchTree) sizeRec() (res int) {
-	return unfolding acc(t.Inv(), _) in 1 + (t.Left == nil ? 0 : t.Left.sizeRec()) + (t.Right == nil ? 0 : t.Right.sizeRec())
+decreases
+pure func (n *ImplicitBinarySearchNode) Size(min, max uint64) (res int) {
+	return n == nil ? 0 : unfolding acc(n.Inv(min, max), _) in n.sizeRec(min, max)
 }
 
 ghost
-requires acc(t.Inv(), _)
-ensures  0 <= res && res <= t.Max()
-decreases acc(t.Inv(), _)
-pure func (t *ImplicitBinarySearchTree) Min() (res uint64) {
-	return unfolding acc(t.Inv(), _) in t.Left == nil ? t.Root : t.Left.Min()
-}
-
-ghost
-requires acc(t.Inv(), _)
-decreases acc(t.Inv(), _)
-pure func (t *ImplicitBinarySearchTree) Max() uint64 {
-	return unfolding acc(t.Inv(), _) in t.Right == nil ? t.Root : t.Right.Max()
+requires acc(n.Inv(min, max), _)
+ensures  0 < res
+decreases acc(n.Inv(min, max), _)
+pure func (n *ImplicitBinarySearchNode) sizeRec(min, max uint64) (res int) {
+	return unfolding acc(n.Inv(min, max), _) in 1 + (n.Left == nil ? 0 : unfolding acc(n.Left.Inv(min, n.Root - 1), _) in n.Left.sizeRec(min, n.Root - 1)) + (n.Right == nil ? 0 : unfolding acc(n.Right.Inv(n.Root + 1, max), _) in n.Right.sizeRec(n.Root + 1, max))
 }
 @*/
 
@@ -94,146 +101,124 @@ func RootNode(treeSize uint64) (root uint64) {
 
 /*@
 ghost
+ensures 1 <= treeSize ==> root < treeSize
 decreases treeSize
 pure func RootNodePure(treeSize uint64) (root uint64) {
 	return treeSize == 0 ? 0 : utils.PowOf2_pure(utils.Log2Floor_pure(treeSize)) - 1
 }
 @*/
 
-// @ preserves tree != nil ==> tree.Inv()
-// @ requires  0 <= offset
-// @ ensures   old(tree.Size()) == tree.Size()
-// @ ensures   tree != nil ==> old(tree.Min()) + offset == tree.Min()
-// @ ensures   tree != nil ==> old(tree.Max()) + offset == tree.Max()
-// @ decreases tree.Size()
-func (tree *ImplicitBinarySearchTree) OffSet(offset uint64) {
-	if tree != nil {
-		//@ unfold tree.Inv()
-		tree.Root += offset
-		tree.Left.OffSet(offset)
-		tree.Right.OffSet(offset)
-		//@ fold tree.Inv()
-	}
-	return
-}
-
 // @ requires  noPerm < p
 // @ preserves acc(tree.Inv(), p)
+// @ ensures   (err == nil) == (0 <= nodeVal && nodeVal < tree.Size())
 // @ ensures   err == nil ==> acc(path)
-func (tree *ImplicitBinarySearchTree) PathTo(node uint64 /*@, ghost p perm @*/) (path []uint64, err error) {
+// @ decreases
+func (tree *ImplicitBinarySearchTree) PathTo(nodeVal uint64 /*@, ghost p perm @*/) (path []uint64, err error) {
 	//@ unfold acc(tree.Inv(), p)
-	if tree.Root == node {
-		path = []uint64{node}
+	if tree.tree == nil {
+		err = errors.New("no paths exist in an empty tree")
 	} else {
-		var recurse *ImplicitBinarySearchTree
-		if tree.Root < node {
-			recurse = tree.Right
-		} else { // tree.Root > node
-			recurse = tree.Left
-		}
-		if recurse == nil {
-			err = errors.New("not found")
-		} else {
-			path, err = recurse.PathTo(node /*@, p/2 @*/)
-		}
-		if err == nil {
-			path = append( /*@ p, @*/ []uint64{tree.Root}, path...)
-		}
+		path, err = tree.tree.pathTo(nodeVal /*@, 0, tree.size - 1, p/2 @*/)
 	}
 	//@ fold acc(tree.Inv(), p)
 	return
 }
 
-// Currently, magic wands do not get correctly processed by the SIF plugin
-// //@ requires  noPerm < p
-// //@ preserves tree != nil ==> acc(tree.Inv(), p)
-// //@ ensures   acc(path)
-// //@ ensures   tree != nil ==> len(path) > 0
-// func (tree *ImplicitBinarySearchTree) FrontierNodes( /*@ ghost p perm @*/ ) (path []uint64) {
-// 	path = []uint64{}
-
-// 	if tree == nil {
-// 		return
-// 	}
-
-// 	t := tree
-// 	//@ package acc(t.Inv(), p) --* acc(tree.Inv(), p)
-// 	// temporarily unfold the invariant to obtain the knowledge that t cannot be nil:
-// 	//@ assert unfolding acc(tree.Inv(), p) in t != nil
-
-//		//@ invariant acc(path)
-//		//@ invariant t != nil ==> acc(t.Inv(), p)
-//		//@ invariant t != nil ==> acc(t.Inv(), p) --* acc(tree.Inv(), p)
-//		//@ invariant t == nil ==> acc(tree.Inv(), p)
-//		//@ invariant t == nil ==> len(path) > 0
-//		for t != nil {
-//			//@ unfold acc(t.Inv(), p)
-//			path = append( /*@ p, @*/ path, t.Root)
-//			//@ ghost oldT := t
-//			t = t.Right
-//			/*@
-//			ghost if t == nil {
-//				fold acc(oldT.Inv(), p)
-//				apply acc(oldT.Inv(), p) --* acc(tree.Inv(), p)
-//			} else {
-//				package acc(t.Inv(), p) --* acc(tree.Inv(), p) {
-//					fold acc(oldT.Inv(), p)
-//					apply acc(oldT.Inv(), p) --* acc(tree.Inv(), p)
-//				}
-//			}
-//			@*/
-//		}
-//		return
-//	}
-//
 // @ requires  noPerm < p
-// @ preserves tree != nil ==> acc(tree.Inv(), p)
-// @ ensures   acc(path)
-// @ ensures   (tree == nil) == (0 == len(path))
-// @ ensures   tree != nil ==> forall j int :: { path[j] } 0 <= j && j < len(path) ==> tree.Min() <= path[j] && path[j] <= tree.Max()
-// ensures   tree != nil ==> unfolding acc(tree.Inv(), p) in low(tree.Root) ==> (low(len(path)) && forall i int :: { path[i] } 0 <= i && i < len(path) ==> low(path[i]))
-// @ decreases tree.Size()
-func (tree *ImplicitBinarySearchTree) FrontierNodes( /*@ ghost p perm @*/ ) (path []uint64) {
-	if tree != nil {
-		//@ unfold acc(tree.Inv(), p/2)
-		path = []uint64{tree.Root}
-		//@ assert low(len(path))
-		//@ assert forall j int :: { path[j] } 0 <= j && j < len(path) && low(tree.Root) ==> low(path[j])
-		// assert tree.Right == nil ==> low(tree.Right)
-		// assert tree.Right != nil ==> unfolding tree.Right.Inv() in low(tree.Right.Root)
-		subtreePath := tree.Right.FrontierNodes( /*@ p/4 @*/ )
-		// assert low(len(subtreePath))
-		// assert forall j int :: 0 <= j && j < len(subtreePath) ==> low(subtreePath[j])
-		path = append( /*@ perm(1/2), @*/ path, subtreePath...)
-		// assert low(len(path))
-		// assert forall j int :: 0 <= j && j < len(path) ==> low(path[j])
-		//@ fold acc(tree.Inv(), p/2)
+// @ preserves acc(node.Inv(min, max), p)
+// @ requires  min <= max
+// @ ensures   (err == nil) == (min <= nodeVal && nodeVal <= max)
+// @ ensures   err == nil ==> acc(path)
+// @ decreases max - min
+func (node *ImplicitBinarySearchNode) pathTo(nodeVal uint64 /*@, ghost min, max uint64, ghost p perm @*/) (path []uint64, err error) {
+	//@ unfold acc(node.Inv(min, max), p/2)
+	if node.Root == nodeVal {
+		path = []uint64{nodeVal}
+	} else {
+		var recurse *ImplicitBinarySearchNode
+		//@ ghost var minRec, maxRec uint64 = min, max
+		if node.Root < nodeVal {
+			recurse = node.Right
+			//@ minRec = node.Root + 1
+		} else { // node.Root > nodeVal
+			recurse = node.Left
+			//@ maxRec = node.Root - 1
+		}
+		if recurse == nil {
+			err = errors.New("not found")
+		} else {
+			path, err = recurse.pathTo(nodeVal /*@, minRec, maxRec, p/4 @*/)
+		}
+		if err == nil {
+			path = append( /*@ perm(1/2), @*/ []uint64{node.Root}, path...)
+		}
 	}
+	//@ fold acc(node.Inv(min, max), p/2)
+	return
+}
+
+// @ requires  noPerm < p
+// @ preserves acc(tree.Inv(), p)
+// @ ensures   acc(path)
+// @ ensures   uint64(len(path)) <= tree.Size()
+// @ ensures   forall j int :: { path[j] } 0 <= j && j < len(path) ==> 0 <= path[j] && path[j] < tree.Size()
+// @ ensures   low(tree.Size()) ==> low(len(path)) && forall i int :: { path[i] } 0 <= i && i < len(path) ==> low(path[i])
+// @ decreases
+func (tree *ImplicitBinarySearchTree) FrontierNodes( /*@ ghost p perm @*/ ) (path []uint64) {
+	//@ unfold acc(tree.Inv(), p/2)
+	if tree.tree != nil {
+		path = tree.tree.frontierNodes( /*@ 0, tree.size - 1, p/4 @*/ )
+	}
+	//@ fold acc(tree.Inv(), p/2)
+	return
+}
+
+// @ requires  noPerm < p
+// @ preserves acc(node.Inv(min, max), p)
+// @ ensures   acc(path)
+// @ ensures   uint64(len(path)) <= max - min + 1
+// @ ensures   forall j int :: { path[j] } 0 <= j && j < len(path) ==> min <= path[j] && path[j] <= max
+// @ ensures   low(min) && low(max) ==> low(len(path)) && forall i int :: { path[i] } 0 <= i && i < len(path) ==> low(path[i])
+// @ decreases acc(node.Inv(min, max), p)
+func (node *ImplicitBinarySearchNode) frontierNodes( /*@ ghost min, max uint64, ghost p perm @*/ ) (path []uint64) {
+	//@ unfold acc(node.Inv(min, max), p/2)
+	path = []uint64{node.Root}
+	if node.Right != nil {
+		subtreePath := node.Right.frontierNodes( /*@ node.Root + 1, max, p/4 @*/ )
+		path = append( /*@ perm(1/2), @*/ path, subtreePath...)
+	}
+	//@ fold acc(node.Inv(min, max), p/2)
 	return
 }
 
 // @ requires 0 <= treeSize
-// @ ensures  tree != nil ==> tree.Inv() && tree.Min() == 0 && tree.Max() == treeSize - 1
-// @ ensures  treeSize == uint64(tree.Size())
-// @ ensures  (treeSize == 0) == (tree == nil)
-// @ ensures  tree != nil ==> unfolding tree.Inv() in low(treeSize) ==> low(tree.Root)
-// @ decreases treeSize
+// @ ensures  tree.Inv() && tree.Size() == treeSize
+// @ decreases
 func MkImplicitBinarySearchTree(treeSize uint64) (tree *ImplicitBinarySearchTree) {
-	if treeSize == 0 {
-		tree = nil
-	} else if treeSize == 1 {
-		root := RootNode(treeSize)
-		tree = &ImplicitBinarySearchTree{root, nil, nil}
-		//@ fold tree.Inv()
-		//@ assert tree.Size() == 1
-	} else if treeSize > 1 {
-		root := RootNode(treeSize)
-		left := MkImplicitBinarySearchTree(root)
-		right := MkImplicitBinarySearchTree(treeSize - root - 1)
-		right.OffSet(root + 1)
-		tree = &ImplicitBinarySearchTree{root, left, right}
-		//@ fold tree.Inv()
+	root := mkImplicitBinarySearchNode(0, treeSize-1)
+	tree = &ImplicitBinarySearchTree{treeSize, root}
+	//@ fold tree.Inv()
+	return
+}
+
+// @ requires 0 <= min && min <= max + 1
+// @ ensures  (min <= max) == (node != nil)
+// @ ensures  node != nil ==> node.Inv(min, max)
+// @ ensures  node != nil ==> uint64(node.Size(min, max)) == max - min + 1
+// @ decreases max - min
+func mkImplicitBinarySearchNode(min, max uint64) (node *ImplicitBinarySearchNode) {
+	if min == max { // treeSize == 1
+		root := RootNode(max-min+1) + min
+		node = &ImplicitBinarySearchNode{root, nil, nil}
+		//@ fold node.Inv(min, max)
+	} else if min < max {
+		root := RootNode(max-min+1) + min
+		left := mkImplicitBinarySearchNode(min, root-1)
+		right := mkImplicitBinarySearchNode(root+1, max)
+		node = &ImplicitBinarySearchNode{root, left, right}
+		//@ fold node.Inv(min, max)
 	}
+	// else: min == max+1 and node == nil
 	return
 }
 
@@ -256,6 +241,7 @@ pred (s *UserState) Inv() {
 // @ requires noPerm < p
 // @ preserves acc(timestamps, p)
 // @ ensures res ==> forall i, j int :: { timestamps[i], timestamps[j] } 0 <= i && i < j && j < len(timestamps) ==> timestamps[i] <= timestamps[j]
+// @ decreases
 func checkIncreasing(timestamps []uint64 /*@, ghost p perm @*/) (res bool) {
 	res = true
 	if len(timestamps) > 0 {
@@ -264,6 +250,7 @@ func checkIncreasing(timestamps []uint64 /*@, ghost p perm @*/) (res bool) {
 		//@ invariant acc(timestamps, p)
 		//@ invariant res ==> forall i int :: { timestamps[i] } 0 <= i && i < k ==> timestamps[i] <= tmp
 		//@ invariant res ==> forall i, j int :: { timestamps[i], timestamps[j] } 0 <= i && i < j && j < k ==> timestamps[i] <= timestamps[j]
+		//@ decreases len(timestamps) - k
 		for k := 0; k < len(timestamps); k++ {
 			v := timestamps[k]
 			if tmp > v {
@@ -278,20 +265,20 @@ func checkIncreasing(timestamps []uint64 /*@, ghost p perm @*/) (res bool) {
 
 // @ requires  noPerm < p
 // @ preserves st.Inv()
-// @ preserves acc(new_head.Inv(), p)
+// @ preserves acc(newHead.Inv(), p)
 // since we take the timestamps from `prf`, we need full permissions to then
 // @ preserves acc(prf.Inv(), p)
-// @ ensures err == nil ==> unfolding st.Inv() in st.Size == new_head.Size()
-// @ ensures err == nil && low(new_head.Size()) ==> unfolding st.Inv() in low(st.Size)
+// @ ensures err == nil ==> unfolding st.Inv() in st.Size == newHead.Size()
+// @ ensures err == nil && low(newHead.Size()) ==> unfolding st.Inv() in low(st.Size)
 // @ trusted
-func (st *UserState) UpdateView(new_head FullTreeHead, prf proofs.CombinedTreeProof /*@, ghost p perm @*/) (err error) {
+func (st *UserState) UpdateView(newHead FullTreeHead, prf proofs.CombinedTreeProof /*@, ghost p perm @*/) (err error) {
 	//@ unfold acc(prf.Inv(), p)
 
 	if !checkIncreasing(prf.Timestamps /*@, p/2 @*/) {
 		//@ fold acc(prf.Inv(), p)
 		return errors.New("timestamps not increasing")
 	}
-	if new_head.Tree_head.Tree_size == 0 {
+	if newHead.Tree_head.Tree_size == 0 {
 		//@ fold acc(prf.Inv(), p)
 		return errors.New("new tree cannot be empty")
 	}
@@ -304,7 +291,7 @@ func (st *UserState) UpdateView(new_head FullTreeHead, prf proofs.CombinedTreePr
 	origTimestamps := st.Frontier_timestamps
 
 	oldSearchTree := MkImplicitBinarySearchTree(st.Size)
-	newSearchTree := MkImplicitBinarySearchTree(new_head.Tree_head.Tree_size)
+	newSearchTree := MkImplicitBinarySearchTree(newHead.Tree_head.Tree_size)
 	oldFrontier := oldSearchTree.FrontierNodes( /*@ 1/2 @*/ )
 	newFrontier := newSearchTree.FrontierNodes( /*@ 1/2 @*/ )
 
@@ -367,7 +354,7 @@ func (st *UserState) UpdateView(new_head FullTreeHead, prf proofs.CombinedTreePr
 	copy(newSubtrees, prf.Inclusion.Elements)
 	st.Full_subtrees = newSubtrees
 
-	st.Size = new_head.Tree_head.Tree_size
+	st.Size = newHead.Tree_head.Tree_size
 
 	//@ fold st.Inv()
 	//@ fold acc(prf.Inv(), p)

--- a/pkg/client/treeview.go
+++ b/pkg/client/treeview.go
@@ -112,6 +112,7 @@ pure func RootNodePure(treeSize uint64) (root uint64) {
 // @ preserves acc(tree.Inv(), p)
 // @ ensures   (err == nil) == (0 <= nodeVal && nodeVal < tree.Size())
 // @ ensures   err == nil ==> acc(path)
+// @ ensures   err == nil ==> forall i int :: { path[i] } 0 <= i && i < len(path) ==> 0 <= path[i] && path[i] < tree.Size()
 // @ decreases
 func (tree *ImplicitBinarySearchTree) PathTo(nodeVal uint64 /*@, ghost p perm @*/) (path []uint64, err error) {
 	//@ unfold acc(tree.Inv(), p)
@@ -129,6 +130,7 @@ func (tree *ImplicitBinarySearchTree) PathTo(nodeVal uint64 /*@, ghost p perm @*
 // @ requires  min <= max
 // @ ensures   (err == nil) == (min <= nodeVal && nodeVal <= max)
 // @ ensures   err == nil ==> acc(path)
+// @ ensures   err == nil ==> forall i int :: { path[i] } 0 <= i && i < len(path) ==> min <= path[i] && path[i] <= max
 // @ decreases max - min
 func (node *ImplicitBinarySearchNode) pathTo(nodeVal uint64 /*@, ghost min, max uint64, ghost p perm @*/) (path []uint64, err error) {
 	//@ unfold acc(node.Inv(min, max), p/2)

--- a/pkg/client/treeview.go
+++ b/pkg/client/treeview.go
@@ -161,7 +161,9 @@ func (node *ImplicitBinarySearchNode) pathTo(nodeVal uint64 /*@, ghost min, max 
 // @ preserves acc(tree.Inv(), p)
 // @ ensures   acc(path)
 // @ ensures   uint64(len(path)) <= tree.Size()
+// @ ensures   0 < tree.Size() ==> 0 < len(path)
 // @ ensures   forall j int :: { path[j] } 0 <= j && j < len(path) ==> 0 <= path[j] && path[j] < tree.Size()
+// @ ensures   0 < tree.Size() ==> path[len(path) - 1] == tree.Size() - 1
 // @ ensures   low(tree.Size()) ==> low(len(path)) && forall i int :: { path[i] } 0 <= i && i < len(path) ==> low(path[i])
 // @ decreases
 func (tree *ImplicitBinarySearchTree) FrontierNodes( /*@ ghost p perm @*/ ) (path []uint64) {
@@ -176,8 +178,10 @@ func (tree *ImplicitBinarySearchTree) FrontierNodes( /*@ ghost p perm @*/ ) (pat
 // @ requires  noPerm < p
 // @ preserves acc(node.Inv(min, max), p)
 // @ ensures   acc(path)
+// @ ensures   0 < len(path)
 // @ ensures   uint64(len(path)) <= max - min + 1
 // @ ensures   forall j int :: { path[j] } 0 <= j && j < len(path) ==> min <= path[j] && path[j] <= max
+// @ ensures   path[len(path) - 1] == max
 // @ ensures   low(min) && low(max) ==> low(len(path)) && forall i int :: { path[i] } 0 <= i && i < len(path) ==> low(path[i])
 // @ decreases acc(node.Inv(min, max), p)
 func (node *ImplicitBinarySearchNode) frontierNodes( /*@ ghost min, max uint64, ghost p perm @*/ ) (path []uint64) {

--- a/pkg/prefixtree/prefixproof.go
+++ b/pkg/prefixtree/prefixproof.go
@@ -10,6 +10,21 @@ import (
 	//@ "github.com/felixlinker/keytrans-verification/pkg/utils"
 )
 
+// Recursive prefix tree data structure
+type PrefixTree struct {
+	// Hash value of this node; must be computed if nil
+	Value *[sha256.Size]byte
+	// If set, this node is a leaf of the given value. Left and Right must be nil
+	// in this case.
+	Leaf *proofs.PrefixLeaf
+	// Left subtree. May be nil even if Right is not nil.
+	Left *PrefixTree
+	// Right subtree. May be nil even if Left is not nil.
+	Right *PrefixTree
+}
+
+//@ *PrefixTree implements PT
+
 /*@
 // note that a nil PrefixTree trivially satisfies the Invariant
 pred (t *PrefixTree) Inv() {
@@ -48,19 +63,6 @@ func (t *PrefixTree) GetValue() *[sha256.Size]byte {
 // @ pure
 func (t *PrefixTree) GetValueArray() [sha256.Size]byte {
 	return /*@ unfolding acc(t.Inv(), _) in @*/ *t.Value
-}
-
-// Recursive prefix tree data structure
-type PrefixTree struct {
-	// Hash value of this node; must be computed if nil
-	Value *[sha256.Size]byte
-	// If set, this node is a leaf of the given value. Left and Right must be nil
-	// in this case.
-	Leaf *proofs.PrefixLeaf
-	// Left subtree. May be nil even if Right is not nil.
-	Left *PrefixTree
-	// Right subtree. May be nil even if Left is not nil.
-	Right *PrefixTree
 }
 
 // Creates a prefix tree recursively from a list of binary ladder steps and
@@ -277,15 +279,6 @@ func (tree *PrefixTree) ComputeHash() (hash [sha256.Size]byte, err error) {
 // It is also one of the important lemmas we need to show that the commitment we get is consistent
 // We use the following paper to derive the following lemma
 // Paper: https://arxiv.org/pdf/2501.10802
-
-/*@
-// this captures our assumption that GetCommitment is deterministic
-ghost
-decreases
-// takes seq[byte] inputs so it remains pure (no heap permissions needed)
-// returns bool: true = commitment exists (inclusion), false = no commitment (non-inclusion)
-pure func GetCommitmentExists(label seq[byte], version uint64, rootHash seq[byte]) bool
-@*/
 
 // GetCommitment searches the authenticated prefix tree for the commitment
 // corresponding to the given (label, version) pair.

--- a/pkg/prefixtree/prefixtree-intf.go
+++ b/pkg/prefixtree/prefixtree-intf.go
@@ -1,0 +1,29 @@
+package prefixtree
+
+//@ import "github.com/felixlinker/keytrans-verification/pkg/utils"
+
+/*@
+// this captures our assumption that GetCommitment is deterministic
+ghost
+decreases
+// returns bool: true = commitment exists (inclusion), false = no commitment (non-inclusion)
+pure func GetCommitmentExists(label seq[byte], version uint64, rootHash seq[byte]) (commitmentExists bool)
+@*/
+
+type PT interface {
+	//@ pred Inv()
+
+	// Returns non-nil if we can prove that the prefix tree contains a key for the
+	// label and version pair provided. Returns nil if we can prove that the
+	// prefix tree does not contain a key for the label and version pair provided.
+	// Returns error in any other case.
+	// @ requires  noPerm < p
+	// @ preserves acc(Inv(), p)
+	// @ preserves acc(utils.BytesMem(label), p)
+	// @ preserves acc(utils.BytesMem(rootHash), p)
+	// @ requires  0 <= version
+	// @ ensures   err == nil && res != nil ==> acc(res)
+	// @ ensures   err == nil ==> (res != nil) == GetCommitmentExists(utils.getContent(label), version, utils.getContent(rootHash))
+	// @ decreases
+	GetCommitment(label []byte, version uint64, rootHash []byte /*@, ghost p perm@*/) (res []byte, err error)
+}

--- a/pkg/proofs/ladder.go
+++ b/pkg/proofs/ladder.go
@@ -5,30 +5,19 @@ import "github.com/felixlinker/keytrans-verification/pkg/utils"
 /*@
 ghost
 requires 0 <= t1 && 0 <= t2
-ensures t1 != t2 ==> min(t1, t2) < r && r <= max(t1, t2)
+ensures t1 != t2 ==> utils.min(t1, t2) < r && r <= utils.max(t1, t2)
 decreases
 pure func TStar_pure(t1 uint64, t2 uint64) (r uint64) {
 	return tStar_pure(t1 + 1, t2 + 1) - 1
 }
-
-ghost
-decreases
-pure func min(a uint64, b uint64) (r uint64) {
-	return a <= b ? a : b
-}
-
-ghost
-decreases
-pure func max(a uint64, b uint64) (r uint64) {
-	return a >= b ? a : b
-}
 @*/
+
 // =============================Core Lemma======================================
 /*@
 ghost
 requires 0 < t1 && 0 < t2
 ensures 1 <= r
-ensures t1 != t2 ==> min(t1, t2) < r && r <= max(t1, t2)
+ensures t1 != t2 ==> utils.min(t1, t2) < r && r <= utils.max(t1, t2)
 decreases
 pure func tStar_pure(t1 uint64, t2 uint64) (r uint64) {
 	return t1 == t2 ? 1 :
@@ -55,9 +44,9 @@ func tStarRec_pure(t1 uint64, t2 uint64, x_in uint64, x_out uint64) (r uint64) {
 }
 
 ghost
-requires 0 < min(t1, t2)
-requires x_in <= min(t1, t2) && min(t1, t2) < x_out
-ensures t1 != t2 ==> min(t1, t2) < r && r <= max(t1, t2)
+requires 0 < utils.min(t1, t2)
+requires x_in <= utils.min(t1, t2) && utils.min(t1, t2) < x_out
+ensures t1 != t2 ==> utils.min(t1, t2) < r && r <= utils.max(t1, t2)
 decreases x_out - x_in
 pure func tStarRec_pure_general(t1 uint64, t2 uint64, x_in uint64, x_out uint64) (r uint64) {
 	return t1 == t2 ? 1 : t1 < t2 ? tStarRec_pure(t1, t2, x_in, x_out) : tStarRec_pure(t2, t1, x_in, x_out)
@@ -237,8 +226,8 @@ func FullBinaryLadderSteps(target uint64 /*@, ghost t2 uint64 @*/) (r []uint64 /
 // us to continue recursively constructing the binary ladder while memorizing
 // that the value stored at acc_idx is tStar.
 // @ requires !found ==> x_in == acc_x_in && x_out == acc_x_out
-// @ requires !found ==> x_in <= min(target, t2) && max(target, t2) < x_out
-// @ requires acc_x_in <= min(target, t2) && min(target, t2) < acc_x_out
+// @ requires !found ==> x_in <= utils.min(target, t2) && utils.max(target, t2) < x_out
+// @ requires acc_x_in <= utils.min(target, t2) && utils.min(target, t2) < acc_x_out
 // @ requires found ==> r[acc_idx] == tStarRec_pure_general(target, t2, acc_x_in, acc_x_out)
 // @ requires target == t2 ==> found
 // @ ensures  acc(res)

--- a/pkg/utils-rel/hash-rel.gobra
+++ b/pkg/utils-rel/hash-rel.gobra
@@ -1,0 +1,54 @@
+package utilsrel
+
+import "crypto/sha256"
+import "github.com/felixlinker/keytrans-verification/pkg/utils"
+
+// ##(--hyperMode extended)
+
+// Build low ghost seq from a *[sha256.Size]byte array
+ghost
+requires noPerm < p
+requires acc(s, p)
+requires forall k int :: { s[k] } 0 <= k && k < sha256.Size ==> low(s[k])
+ensures acc(s, p)
+ensures result == utils.GetHashContent(s)
+ensures low(result)
+decreases
+func buildLowSeqFromHash(s *[sha256.Size]byte, p perm) (result seq[byte]) {
+  invariant acc(s, p/2)
+  invariant 0 <= i && i <= sha256.Size
+  invariant result == utils.getHashContentRec(*s, i)
+  invariant forall k int :: { s[k] } 0 <= k && k < sha256.Size ==> low(s[k])
+  invariant low(i) && low(result)
+  decreases i
+  for i := sha256.Size; i > 0; i-- {
+    result = seq[byte]{s[i - 1]} ++ result
+  }
+  assert result == reveal utils.GetHashContent(s)
+}
+
+ghost
+requires noPerm < p
+requires forall i int :: { &hashes[i] } 0 <= i && i < len(hashes) ==> acc(&hashes[i], p) && acc(hashes[i], p)
+requires low(len(hashes))
+requires forall i, k int :: { hashes[i][k] } 0 <= i && i < len(hashes) && 0 <= k && k < sha256.Size ==> low(hashes[i][k])
+ensures forall i int :: { &hashes[i] } 0 <= i && i < len(hashes) ==> acc(&hashes[i], p) && acc(hashes[i], p)
+ensures len(result) == len(hashes)
+ensures forall i int :: { result[i] } 0 <= i && i < len(result) ==> result[i] == utils.GetHashContent(hashes[i])
+ensures low(result)
+decreases
+func buildRootHashContents(hashes []*[sha256.Size]byte, p perm) (result seq[seq[byte]]) {
+  invariant 0 <= i && i <= len(hashes)
+  invariant forall j int :: { &hashes[j] } 0 <= j && j < len(hashes) ==> acc(&hashes[j], p/2) && acc(hashes[j], p/2)
+  invariant len(result) == i
+  invariant forall i int :: { result[i] } 0 <= i && i < len(result) ==> result[i] == utils.GetHashContent(hashes[i])
+  invariant low(i)
+  invariant low(len(hashes))
+  invariant forall j int :: { &hashes[j] } 0 <= j && j < len(hashes) ==> forall k int :: {hashes[j][k]} 0 <= k && k < sha256.Size ==> low(hashes[j][k])
+  invariant low(result)  
+  decreases len(hashes) - i
+  for i := 0; i < len(hashes); i++ {
+    s := buildLowSeqFromHash(hashes[i], p/4)
+    result = result ++ seq[seq[byte]]{s}
+  }
+}

--- a/pkg/utils/bytes.gobra
+++ b/pkg/utils/bytes.gobra
@@ -19,7 +19,7 @@ ghost
 requires acc(BytesMem(s), _)
 decreases
 opaque
-pure func getContent(s []byte) (res seq[byte]) {
+pure func getContent(s []byte) seq[byte] {
   return unfolding acc(BytesMem(s), _) in getByteContent(s, 0)
 }
 
@@ -27,6 +27,6 @@ ghost
 requires acc(s)
 requires 0 <= idx && idx <= len(s)
 decreases len(s) - idx
-pure func getByteContent(s []byte, idx int) (res seq[byte]) {
+pure func getByteContent(s []byte, idx int) seq[byte] {
   return idx == len(s) ? seq[byte]{} : seq[byte]{s[idx]} ++ getByteContent(s, idx + 1)
 }

--- a/pkg/utils/hash.gobra
+++ b/pkg/utils/hash.gobra
@@ -14,5 +14,5 @@ ghost
 requires 0 <= idx && idx <= sha256.Size
 decreases sha256.Size - idx
 pure func getHashContentRec(s [sha256.Size]byte, idx int) seq[byte] {
-  return idx == sha256.Size ? seq[byte]{} : seq[byte]{s[idx]} ++ getHashContentRec(s, idx + 1)  
+  return idx == sha256.Size ? seq[byte]{} : seq[byte]{s[idx]} ++ getHashContentRec(s, idx + 1)
 }

--- a/pkg/utils/hash.gobra
+++ b/pkg/utils/hash.gobra
@@ -1,0 +1,18 @@
+package utils
+
+import "crypto/sha256"
+
+ghost
+requires acc(s, _)
+decreases
+opaque
+pure func GetHashContent(s *[sha256.Size]byte) seq[byte] {
+    return getHashContentRec(*s, 0)
+}
+
+ghost
+requires 0 <= idx && idx <= sha256.Size
+decreases sha256.Size - idx
+pure func getHashContentRec(s [sha256.Size]byte, idx int) seq[byte] {
+  return idx == sha256.Size ? seq[byte]{} : seq[byte]{s[idx]} ++ getHashContentRec(s, idx + 1)  
+}

--- a/pkg/utils/maths.go
+++ b/pkg/utils/maths.go
@@ -14,43 +14,59 @@ pure func max(a, b uint64) uint64 {
 }
 
 ghost
-ensures r >= 0
-ensures n >= 1 ==> PowOf2_pure(r) <= n && PowOf2_pure(r+1) > n && r < n
+ensures 0 <= r
+ensures 1 <= n ==> PowOf2_pure(r) <= n && n < PowOf2_pure(r+1) && r < n
 ensures n == 1 ==> r == 0
 decreases n
-pure
-func Log2Floor_pure(n uint64) (r uint64) {
+pure func Log2Floor_pure(n uint64) (r uint64) {
     return n < 2 ? 0 : 1 + Log2Floor_pure(n / 2)
 }
 
 ghost
-requires a > 0
-requires b > 0
-requires a <= b
-ensures Log2Floor_pure(a) <= Log2Floor_pure(b)
-ensures a <= b/2 ==> Log2Floor_pure(a) < Log2Floor_pure(b)
+requires  0 < a && 0 < b
+requires  a <= b
+ensures   Log2Floor_pure(a) <= Log2Floor_pure(b)
+ensures   a <= b/2 ==> Log2Floor_pure(a) < Log2Floor_pure(b)
 decreases b
-pure
-func Log2FloorMonotonic(a uint64, b uint64) uint64 {
+pure func Log2FloorMonotonic(a uint64, b uint64) uint64 {
 	return a == b ? 0 :
 		(b == 1 ? 0 :
 			(a == 1 ? Log2FloorMonotonic(1, b/2) :
 				Log2FloorMonotonic(a/2,b/2)))
 }
+
+ghost
+requires 0 <= i
+requires Log2Floor_pure(prev) == i
+requires Log2Floor_pure(next) == i + 1
+requires next == PowOf2_pure(i + 1)
+requires prev <= n && n < next
+ensures  Log2Floor_pure(n) == i
+decreases
+func Log2FloorInbetween(i, prev, n, next uint64) {
+	ghost if Log2Floor_pure(n) < i {
+		PowOf2Monotonic(Log2Floor_pure(n) + 1, i)
+		assert false
+	}
+	ghost if i < Log2Floor_pure(n) {
+		PowOf2Monotonic(i + 1, Log2Floor_pure(n))
+		assert false
+	}
+}
 @*/
 
-// @ requires base > 0
-// @ ensures r >= 0
-// @ ensures PowOf2_pure(r) <= base
-// @ ensures base < PowOf2_pure(r+1)
-// @ ensures r == Log2Floor_pure(base)
+// @ requires  0 < base
+// @ ensures   0 <= r
+// @ ensures   PowOf2_pure(r) <= base
+// @ ensures   base < PowOf2_pure(r+1)
+// @ ensures   r == Log2Floor_pure(base)
 // @ decreases base
 func Log2Floor(base uint64) (r uint64) {
 	if base <= 1 {
 		//@ assert Log2Floor_pure(base) == 0
 		return 0
 	} else {
-		//@ assert base > 1
+		//@ assert 1 < base
 		//@ assert Log2Floor_pure(base) == 1 + Log2Floor_pure(base / 2)
 		return 1 + Log2Floor(base/2)
 	}
@@ -58,39 +74,37 @@ func Log2Floor(base uint64) (r uint64) {
 
 /*@
 ghost
-requires exp >= 0
-ensures r > 0
+requires  0 <= exp
+ensures   0 < r
 decreases exp
-pure
-func PowOf2_pure(exp uint64) (r uint64) {
+pure func PowOf2_pure(exp uint64) (r uint64) {
   return exp == 0 ? 1 : 2 * PowOf2_pure(exp - 1)
 }
 
 // Lemma: Weaker version of PowOf2_pureIncLemma
 ghost
-requires a >= 0
-requires b >= 0
-requires a <= b
-ensures PowOf2_pure(a) <= PowOf2_pure(b)
-ensures a < b ==> PowOf2_pure(a) < PowOf2_pure(b)
+requires  0 <= a
+requires  0 <= b
+requires  a <= b
+ensures   PowOf2_pure(a) <= PowOf2_pure(b)
+ensures   a < b ==> PowOf2_pure(a) < PowOf2_pure(b)
 decreases b - a
-pure
-func PowOf2Monotonic(a uint64, b uint64) uint64 {
+pure func PowOf2Monotonic(a uint64, b uint64) uint64 {
 	return a == b ? 0 : PowOf2Monotonic(a, b - 1)
 }
 @*/
 
-// @ requires exp >= 0
-// @ ensures r == PowOf2_pure(exp)
-// @ ensures 1 <= r
+// @ requires 0 <= exp
+// @ ensures  r == PowOf2_pure(exp)
+// @ ensures  1 <= r
 // @ decreases
 func PowOf2(exp uint64) (r uint64) {
-	var i uint64
 	r = 1
-	//@ invariant i >= 0 && i<= exp
+
+	//@ invariant 0 <= i && i <= exp
 	//@ invariant r == PowOf2_pure(i)
 	//@ decreases exp - i
-	for i = 0; i < exp; i += 1 {
+	for i := uint64(0); i < exp; i++ {
 		r = r * 2
 	}
 	return r

--- a/pkg/utils/maths.go
+++ b/pkg/utils/maths.go
@@ -2,6 +2,18 @@ package utils
 
 /*@
 ghost
+decreases
+pure func min(a, b uint64) uint64 {
+  return a < b ? a : b
+}
+
+ghost
+decreases
+pure func max(a, b uint64) uint64 {
+  return a > b ? a : b
+}
+
+ghost
 ensures r >= 0
 ensures n >= 1 ==> PowOf2_pure(r) <= n && PowOf2_pure(r+1) > n && r < n
 ensures n == 1 ==> r == 0


### PR DESCRIPTION
The spec for `buildPrefixTrees` is a bit unclear and I've tried to combine the existing one with what we need to verify `VerifyLatest`. However, we should revisit this once we change the `client` package to use the new prefix tree package