### PR TITLE
Adapts prefixLeaf.Inv() and Prefix.Inv() to hold for nil values

### DIFF
--- a/pkg/client/treeview.go
+++ b/pkg/client/treeview.go
@@ -83,7 +83,7 @@ func (st *UserState) UpdateView(newSize uint64, timestamps []uint64, prf *proofs
 			st.Tree = newTree
 
 			// @ unfold acc(utils.Monotonic(timestamps), p)
-			// @ assert forall i, j int :: {st.Frontier_timestamps[i]} 0 <= i && i < len(st.Frontier_timestamps) && 0 < j && j < len(timestamps) ==> st.Frontier_timestamps[i] < timestamps[j]
+			// @ assert forall i, j int :: {st.Frontier_timestamps[i], timestamps[j]} 0 <= i && i < len(st.Frontier_timestamps) && 0 < j && j < len(timestamps) ==> st.Frontier_timestamps[i] < timestamps[j]
 
 			frontier := search.Frontier(newSize)
 			keep := len(frontier) - len(timestamps)

--- a/pkg/trees/misc/misc.go
+++ b/pkg/trees/misc/misc.go
@@ -32,21 +32,20 @@ func mergeValues(ns1, ns2 []*proofs.NodeValue) (ns []*proofs.NodeValue) {
 	return
 }
 
-// @ requires acc(prf1.Inv())
-// @ requires acc(prf2.Inv())
-// @ ensures  acc(prf.Inv())
+// @ requires prf1.Inv()
+// @ requires prf2.Inv()
+// @ ensures  prf.Inv()
 func MergeProofs(prf1, prf2 *proofs.PrefixProof) (prf *proofs.PrefixProof) {
-	// @ unfold acc(prf1.Inv())
-	// @ unfold acc(prf2.Inv())
+	// @ unfold prf1.Inv()
+	// @ unfold prf2.Inv()
 	rs := mergeResults(prf1.Results, prf2.Results)
-	// @ assert acc(proofs.PrefixSearchResultsInv(rs))
+	// @ assert proofs.PrefixSearchResultsInv(rs)
 	ns := mergeValues(prf1.Elements, prf2.Elements)
-	// @ assert acc(proofs.NodeValuesInv(ns))
-	tmp /*@@@*/ := proofs.PrefixProof{
+	// @ assert proofs.NodeValuesInv(ns)
+	prf = &proofs.PrefixProof{
 		Results:  rs,
 		Elements: ns,
 	}
-	prf = &tmp
-	// @ fold acc(prf.Inv())
+	// @ fold prf.Inv()
 	return
 }

--- a/pkg/trees/prefix.go
+++ b/pkg/trees/prefix.go
@@ -19,22 +19,20 @@ type prefixLeaf struct {
 }
 
 /*@
-// note that a `nil` prefixLeaf satisfies the invariant.
 pred (l *prefixLeaf) Inv() {
-	l != nil ==>
-		acc(l) &&
-		(l.searchKey != nil ==> acc(l.searchKey)) &&
-		(l.commitment != nil ==> acc(l.commitment))
+	acc(l) &&
+	(l.searchKey != nil ==> acc(l.searchKey)) &&
+	(l.commitment != nil ==> acc(l.commitment))
 }
 @*/
 
 // @ requires  noPerm < p
-// @ preserves acc(pl.Inv(), p)
-// @ ensures   l.Inv()
-// @ ensures   pl != nil ==> l != nil
+// @ preserves pl != nil ==> acc(pl.Inv(), p)
+// @ ensures   pl != nil ==> l.Inv()
 func commitmentLeaf(pl *proofs.PrefixLeaf /*@, ghost p perm @*/) (l *prefixLeaf) {
-	// @ unfold acc(pl.Inv(), p)
 	if pl != nil {
+		// @ unfold acc(pl.Inv(), p)
+
 		// Spec: leaf.value = Hash(0x02 || vrf_output || commitment)
 		input := []byte{0x02}
 		input = append( /*@ p, @*/ input, pl.Vrf_output...)
@@ -52,9 +50,9 @@ func commitmentLeaf(pl *proofs.PrefixLeaf /*@, ghost p perm @*/) (l *prefixLeaf)
 			searchKey:  append( /*@ p, @*/ []byte{}, pl.Vrf_output...),
 			commitment: &c,
 		}
+		// @ fold l.Inv()
+		// @ fold acc(pl.Inv(), p)
 	}
-	// @ fold l.Inv()
-	// @ fold acc(pl.Inv(), p)
 	return
 }
 
@@ -65,13 +63,11 @@ type Prefix struct {
 }
 
 /*@
-// note that a `nil` Prefix satisfies the invariant.
 pred (t *Prefix) Inv() {
-	t != nil ==>
-		acc(t) &&
-		(t.leaf != nil ==> acc(t.leaf.Inv())) &&
-		t.left.Inv() &&
-		t.right.Inv()
+	acc(t) &&
+	(t.leaf != nil ==> t.leaf.Inv()) &&
+	(t.left != nil ==> t.left.Inv()) &&
+	(t.right != nil ==> t.right.Inv())
 }
 @*/
 
@@ -81,11 +77,9 @@ pred PrefixesInv(ts []*Prefix) {
 }
 @*/
 
-// @ ensures t.Inv() && t != nil
+// @ ensures t.Inv()
 func mkTree() (t *Prefix) {
 	t = &Prefix{}
-	// @ fold t.left.Inv()
-	// @ fold t.right.Inv()
 	// @ fold t.Inv()
 	return
 }
@@ -198,14 +192,12 @@ func nodeValueLeaf(nodeValue proofs.NodeValue) (t *Prefix) {
 		left:  nil,
 		right: nil,
 	}
-	// @ fold t.left.Inv()
-	// @ fold t.right.Inv()
 	// @ fold t.Inv()
 	return
 }
 
 // @ requires  0 <= depth && depth <= len(steps)
-// @ requires  t.Inv() && leaf.Inv() && t != nil
+// @ requires  t.Inv() && leaf.Inv()
 // @ preserves acc(steps)
 // @ ensures   t.Inv()
 func (t *Prefix) setLeaf(steps []bool, depth int, leaf *prefixLeaf) {
@@ -214,8 +206,6 @@ func (t *Prefix) setLeaf(steps []bool, depth int, leaf *prefixLeaf) {
 		t.leaf = leaf
 		t.left = nil
 		t.right = nil
-		// @ fold t.left.Inv()
-		// @ fold t.right.Inv()
 	} else {
 		stepsRec := steps[1:]
 		// @ assert forall i int :: {&stepsRec[i]} 0 <= i && i < len(stepsRec) ==> &stepsRec[i] == &steps[i+1]
@@ -236,7 +226,7 @@ func (t *Prefix) setLeaf(steps []bool, depth int, leaf *prefixLeaf) {
 
 // @ requires  noPerm < p
 // @ requires  acc(proofs.NodeValuesInv(elements), p)
-// @ preserves t.Inv() && t != nil
+// @ preserves t.Inv()
 // @ ensures err == nil ==> acc(proofs.NodeValuesInv(es), p)
 func (t *Prefix) fill(elements []*proofs.NodeValue /*@, ghost p perm @*/) (es []*proofs.NodeValue, err error) {
 	// @ unfold t.Inv()
@@ -284,8 +274,26 @@ func (t *Prefix) fill(elements []*proofs.NodeValue /*@, ghost p perm @*/) (es []
 
 /*@
 ghost
-requires  acc(t.Inv(), _)
+requires  t != nil ==> acc(t.Inv(), _)
+ensures   0 <= r
 decreases acc(t.Inv(), _)
+pure func (t *Prefix) depth() (r int) {
+	return t == nil ? 0 :
+		unfolding acc(t.Inv(), _) in
+			let lDepth := t.left == nil ? 0 : t.left.depth() in
+			let rDepth := t.right == nil ? 0 : t.right.depth() in
+			1 + max(lDepth, rDepth)
+}
+
+ghost
+decreases
+pure func max(a, b int) int {
+	return a >= b ? a : b
+}
+
+ghost
+requires  t != nil ==> acc(t.Inv(), _)
+decreases t.depth()
 pure func (t *Prefix) Included() (r seq[seq[bool]]) {
 	return (t == nil ?
 		// The empty leaf proves inclusion of no prefix
@@ -298,9 +306,9 @@ pure func (t *Prefix) Included() (r seq[seq[bool]]) {
 }
 
 ghost
-requires  acc(t.Inv(), _)
+requires  t != nil ==> acc(t.Inv(), _)
 requires  0 <= depth
-decreases acc(t.Inv(), _)
+decreases t.depth()
 pure func (t *Prefix) NotIncludedPrefixes(depth int) (r seq[seq[bool]]) {
 	return (t == nil ?
 		// The empty leaf proves non-inclusion of every suffix
@@ -324,9 +332,9 @@ pred NoPrefixMatches(prefixes seq[seq[bool]], values seq[seq[bool]]) {
 @*/
 
 // @ requires noPerm < p
-// @ requires acc(t.Inv(), p)
+// @ requires t != nil ==> acc(t.Inv(), p)
 // @ requires low(t.Included())
-// @ ensures  acc(t.Inv(), p)
+// @ ensures  t != nil ==> acc(t.Inv(), p)
 // // @ ensures low(r) && err == nil ==>
 // // @	NoPrefixMatches(rel(t, 0).NotIncludedPrefixes(0), rel(t, 1).Included()) &&
 // // @	NoPrefixMatches(rel(t, 1).NotIncludedPrefixes(0), rel(t, 0).Included())
@@ -364,30 +372,33 @@ func (t *Prefix) Value( /*@ ghost p perm @*/ ) (r [sha256.Size]byte, err error) 
 // @ preserves acc(searchKey, p)
 // @ requires  acc(t.Inv(), p)
 // @ ensures   acc(t.Inv(), p/2)
-// @ ensures   acc(l.Inv(), p/2)
+// @ ensures   l == nil ==> acc(t.Inv(), p/2)
+// @ ensures   l != nil ==> acc(l.Inv(), p/2)
 func (t *Prefix) getLeaf(searchKey []bool /*@, ghost p perm @*/) (l *prefixLeaf, ok bool) {
 	// @ unfold acc(t.Inv(), p)
-	if t == nil {
-		ok = true
-		// @ fold acc(l.Inv(), p/2)
-	} else if t.leaf != nil || len(searchKey) == 0 {
+	if t.leaf != nil || len(searchKey) == 0 {
 		l = t.leaf
 		ok = t.leaf != nil
-		/*@
-		if l == nil {
-			fold acc(l.Inv(), p/2)
-		}
-		@*/
 	} else {
 		rec := searchKey[1:]
 		// @ assert forall i int :: {&rec[i]} 0 <= i && i < len(rec) ==> &rec[i] == &searchKey[i+1]
 		if searchKey[0] {
-			l, ok = t.right.getLeaf(rec /*@, p @*/)
+			if t.right == nil {
+				l = nil
+				ok = true
+			} else {
+				l, ok = t.right.getLeaf(rec /*@, p @*/)
+			}
 		} else {
-			l, ok = t.left.getLeaf(rec /*@, p @*/)
+			if t.left == nil {
+				l = nil
+				ok = true
+			} else {
+				l, ok = t.left.getLeaf(rec /*@, p @*/)
+			}
 		}
 	}
-	// @ fold acc(t.Inv(), p/2)
+	// @ fold acc(t.Inv(), l == nil ? p : p/2)
 	return
 }
 
@@ -423,8 +434,6 @@ func (t *Prefix) Search(searchKey []byte /*@, ghost p perm @*/) (r *[sha256.Size
 // @ ensures  err == nil ==> tree.Inv()
 func MkPrefix(prf *proofs.PrefixProof /*@, ghost p perm @*/) (tree *Prefix, err error) {
 	tree = &Prefix{}
-	// @ fold tree.left.Inv()
-	// @ fold tree.right.Inv()
 	// @ fold tree.Inv()
 
 	// @ invariant tree.Inv()

--- a/pkg/trees/prefix.go
+++ b/pkg/trees/prefix.go
@@ -19,7 +19,7 @@ type prefixLeaf struct {
 }
 
 /*@
-// note that a `nil` Prefix satisfies the invariant.
+// note that a `nil` prefixLeaf satisfies the invariant.
 pred (l *prefixLeaf) Inv() {
 	l != nil ==>
 		acc(l) &&

--- a/pkg/trees/prefix.go
+++ b/pkg/trees/prefix.go
@@ -84,11 +84,11 @@ func mkTree() (t *Prefix) {
 	return
 }
 
-// @ requires noPerm < p
+// @ requires  noPerm < p
+// @ requires  acc(path, p)
+// @ requires  0 <= depth
+// @ requires  leaf.Inv()
 // @ preserves t.Inv()
-// @ requires acc(path, p)
-// @ requires 0 <= depth
-// @ requires leaf.Inv()
 func (t *Prefix) insertAtChild(path []bool, depth int, leaf *prefixLeaf /*@, ghost p perm @*/) (err error) {
 	// @ unfold t.Inv()
 	if depth >= len(path) {
@@ -108,17 +108,18 @@ func (t *Prefix) insertAtChild(path []bool, depth int, leaf *prefixLeaf /*@, gho
 	return
 }
 
-// @ requires noPerm < p
+// @ requires  noPerm < p
+// @ requires  acc(path, p)
+// @ requires  0 <= depth
+// @ requires  leaf.Inv()
 // @ preserves t.Inv()
-// @ requires acc(path, p)
-// @ requires 0 <= depth
-// @ requires leaf.Inv()
 func (t *Prefix) insert(path []bool, depth int, leaf *prefixLeaf /*@, ghost p perm @*/) (err error) {
-	// @ unfold t.Inv()
-	if t.leaf == nil && t.left == nil && t.right == nil {
+	if /*@ unfolding t.Inv() in @*/ t.leaf == nil && t.left == nil && t.right == nil {
+		// @ unfold t.Inv()
 		t.leaf = leaf
 		// @ fold t.Inv()
 	} else if len(path) <= depth {
+		// @ unfold t.Inv()
 		// We arrived at the maximum depth; overwrite the respective leaf
 		t.leaf = leaf
 		// We assume that search keys are all of equal length. We enforce this
@@ -129,7 +130,8 @@ func (t *Prefix) insert(path []bool, depth int, leaf *prefixLeaf /*@, ghost p pe
 	} else {
 		// If there already is a leaf, "push it down" into the left or right
 		// subtree.
-		if t.leaf != nil {
+		if /*@ unfolding t.Inv() in @*/ t.leaf != nil {
+			// @ unfold t.Inv()
 			recLeaf := t.leaf
 			t.leaf = nil
 			// @ fold t.Inv()
@@ -151,8 +153,8 @@ func (t *Prefix) insert(path []bool, depth int, leaf *prefixLeaf /*@, ghost p pe
 	return
 }
 
+// @ requires  leaf.Inv()
 // @ preserves t.Inv()
-// @ requires leaf.Inv()
 func (t *Prefix) Insert(leaf *prefixLeaf) (err error) {
 	// @ unfold acc(leaf.Inv(), perm(1/2))
 	searchKeyBits := utils.Bits(leaf.searchKey /*@, perm(1/2) @*/)
@@ -160,8 +162,8 @@ func (t *Prefix) Insert(leaf *prefixLeaf) (err error) {
 	return t.insert(searchKeyBits, 0, leaf /*@, perm(1/2) @*/)
 }
 
-// @ requires noPerm < p
-// @ preserves acc(t.Inv(), p)
+// @ requires  noPerm < p
+// @ preserves t != nil ==> acc(t.Inv(), p)
 func (t *Prefix) IsEmpty( /*@ ghost p perm @*/ ) (empty bool) {
 	if t == nil {
 		empty = true
@@ -227,7 +229,7 @@ func (t *Prefix) setLeaf(steps []bool, depth int, leaf *prefixLeaf) {
 // @ requires  noPerm < p
 // @ requires  acc(proofs.NodeValuesInv(elements), p)
 // @ preserves t.Inv()
-// @ ensures err == nil ==> acc(proofs.NodeValuesInv(es), p)
+// @ ensures   err == nil ==> acc(proofs.NodeValuesInv(es), p)
 func (t *Prefix) fill(elements []*proofs.NodeValue /*@, ghost p perm @*/) (es []*proofs.NodeValue, err error) {
 	// @ unfold t.Inv()
 	if t.leaf != nil {
@@ -327,7 +329,7 @@ pred NoPrefixMatches(prefixes seq[seq[bool]], values seq[seq[bool]]) {
 
 // @ requires noPerm < p
 // @ requires t != nil ==> acc(t.Inv(), p)
-// @ requires low(t.Included())
+// // @ requires low(t.Included())
 // @ ensures  t != nil ==> acc(t.Inv(), p)
 // // @ ensures low(r) && err == nil ==>
 // // @	NoPrefixMatches(rel(t, 0).NotIncludedPrefixes(0), rel(t, 1).Included()) &&
@@ -441,13 +443,11 @@ func MkPrefix(prf *proofs.PrefixProof /*@, ghost p perm @*/) (tree *Prefix, err 
 		// TODO: Should verify `result.result_type`, but I skip this for now as it seems to
 		// be redundant information
 
-		searchKey := make([]byte, len(result.Leaf.Vrf_output))
 		// @ unfold acc(result.Leaf.Inv(), p)
+		searchKey := make([]byte, len(result.Leaf.Vrf_output))
 		copy(searchKey, result.Leaf.Vrf_output /*@, p @*/)
-		// @ fold acc(result.Leaf.Inv(), p)
 		searchKeyBits := utils.Bits(searchKey /*@, perm(1/2) @*/)
 
-		// @ unfold acc(result.Leaf.Inv(), p)
 		commitment /*@@@*/ := *result.Leaf.Commitment // Copy commitment
 		// @ fold acc(result.Leaf.Inv(), p)
 		l /*@@@*/ := proofs.PrefixLeaf{Vrf_output: searchKey, Commitment: &commitment}
@@ -470,61 +470,59 @@ func MkPrefix(prf *proofs.PrefixProof /*@, ghost p perm @*/) (tree *Prefix, err 
 	return
 }
 
-// @ requires noPerm < p
+// @ requires  noPerm < p
+// @ requires  0 <= depth
 // @ preserves acc(t.Inv())
 // @ preserves acc(searchKey, p)
-// @ requires 0 <= depth
-// @ requires acc(searchKeyPath, p)
+// @ preserves acc(searchKeyPath, p)
 func (t *Prefix) prune(searchKey []byte, searchKeyPath []bool, depth int /*@, ghost p perm @*/) (err error) {
-	if /*@ unfolding acc(t.Inv()) in @*/ t.leaf != nil {
-		// @ unfold acc(t.Inv())
-		// @ unfold acc(t.leaf.Inv())
+	if /*@ unfolding t.Inv() in @*/ t.leaf != nil {
+		// @ unfold t.Inv()
+		// @ unfold t.leaf.Inv()
 		if t.leaf.searchKey != nil && bytes.Equal(t.leaf.searchKey, searchKey /*@, p, p @*/) {
 			t.leaf.searchKey = nil
 			t.leaf.commitment = nil
 		}
-		// @ fold acc(t.leaf.Inv())
-		// @ fold acc(t.Inv())
+		// @ fold t.leaf.Inv()
+		// @ fold t.Inv()
 	} else if depth < len(searchKeyPath) {
+		// @ unfold t.Inv()
 		if searchKeyPath[depth] {
-			// @ unfold acc(t.Inv())
 			if t.right != nil {
 				err = t.right.prune(searchKey, searchKeyPath, depth+1 /*@, p @*/)
 			}
-			// @ fold acc(t.Inv())
 		} else {
-			// @ unfold acc(t.Inv())
 			if t.left != nil {
 				err = t.left.prune(searchKey, searchKeyPath, depth+1 /*@, p @*/)
 			}
-			// @ fold acc(t.Inv())
 		}
+		// @ fold t.Inv()
 
 		if err == nil && t.IsEmpty( /*@ perm(1/2) @*/ ) {
 			if value, e /*@@@*/ := t.Value( /*@ perm(1/2) @*/ ); e != nil {
 				err = e
 			} else {
-				l /*@@@*/ := prefixLeaf{
+				l := &prefixLeaf{
 					value: value,
 				}
-				// @ fold acc((&l).Inv())
-				// @ unfold acc(t.Inv())
-				t.leaf = &l
+				// @ fold l.Inv()
+				// @ unfold t.Inv()
+				t.leaf = l
 				t.left = nil
 				t.right = nil
-				// @ fold acc(t.Inv())
+				// @ fold t.Inv()
 			}
 		}
 	}
 	return
 }
 
-// @ requires noPerm < p
-// @ preserves acc(t.Inv())
-// @ requires acc(utils.BytesSliceInv(searchKeys), p)
+// @ requires  noPerm < p
+// @ preserves t.Inv()
+// @ preserves acc(utils.BytesSliceInv(searchKeys), p)
 func (t *Prefix) Prune(searchKeys [][]byte /*@, ghost p perm @*/) {
 	// @ invariant 0 <= i && i <= len(searchKeys)
-	// @ invariant acc(t.Inv())
+	// @ invariant t.Inv()
 	// @ invariant acc(utils.BytesSliceInv(searchKeys), p)
 	for i := 0; i < len(searchKeys); i++ {
 		// @ unfold acc(utils.BytesSliceInv(searchKeys), p)
@@ -533,55 +531,54 @@ func (t *Prefix) Prune(searchKeys [][]byte /*@, ghost p perm @*/) {
 	}
 }
 
-// @ ensures acc(prf.Inv())
+// @ ensures prf.Inv()
 func emptyTreeProof() (prf *proofs.PrefixProof) {
-	val /*@@@*/ := proofs.NodeValue{}
-	tmp /*@@@*/ := proofs.PrefixProof{
+	val := &proofs.NodeValue{}
+	prf = &proofs.PrefixProof{
 		Results:  []*proofs.PrefixSearchResult{},
-		Elements: []*proofs.NodeValue{&val},
+		Elements: []*proofs.NodeValue{val},
 	}
-	// @ fold acc(proofs.PrefixSearchResultsInv(tmp.Results))
-	// @ fold acc(proofs.NodeValuesInv(tmp.Elements))
-	// @ fold acc((&tmp).Inv())
-	return &tmp
+	// @ fold proofs.PrefixSearchResultsInv(prf.Results)
+	// @ fold proofs.NodeValuesInv(prf.Elements)
+	// @ fold prf.Inv()
+	return
 }
 
-// @ requires noPerm < p
+// @ requires  noPerm < p
 // @ preserves acc(t.Inv(), p)
-// @ ensures prf != nil ==> acc(prf.Inv())
+// @ ensures   prf.Inv()
 func (t *Prefix) proofFromTree(depth uint8 /*@, ghost p perm @*/) (prf *proofs.PrefixProof) {
 	// @ unfold acc(t.Inv(), p)
 	if t.leaf != nil {
-		tmp /*@@@*/ := proofs.PrefixProof{
+		prf = &proofs.PrefixProof{
 			Results:  []*proofs.PrefixSearchResult{},
 			Elements: []*proofs.NodeValue{},
 		}
-		// @ fold acc(proofs.PrefixSearchResultsInv(tmp.Results))
-		// @ fold acc(proofs.NodeValuesInv(tmp.Elements))
+		// @ fold proofs.PrefixSearchResultsInv(prf.Results)
+		// @ fold proofs.NodeValuesInv(prf.Elements)
 		// @ unfold acc(t.leaf.Inv(), p)
 		if t.leaf.searchKey != nil && t.leaf.commitment != nil {
 			comm /*@@@*/ := *t.leaf.commitment
-			leaf /*@@@*/ := proofs.PrefixLeaf{
+			leaf := &proofs.PrefixLeaf{
 				Vrf_output: make([]byte, len(t.leaf.searchKey)),
 				Commitment: &comm,
 			}
 			copy(leaf.Vrf_output, t.leaf.searchKey /*@, p @*/)
-			// @ fold acc((&leaf).Inv())
-			searchResult /*@@@*/ := proofs.PrefixSearchResult{
-				Leaf:  &leaf,
+			// @ fold leaf.Inv()
+			searchResult := &proofs.PrefixSearchResult{
+				Leaf:  leaf,
 				Depth: depth,
 			}
-			// @ fold acc((&searchResult).Inv())
-			tmp.Results = []*proofs.PrefixSearchResult{&searchResult}
-			// @ fold acc(proofs.PrefixSearchResultsInv(tmp.Results))
+			// @ fold searchResult.Inv()
+			prf.Results = []*proofs.PrefixSearchResult{searchResult}
+			// @ fold proofs.PrefixSearchResultsInv(prf.Results)
 		} else {
 			val /*@@@*/ := t.leaf.value
-			tmp.Elements = []*proofs.NodeValue{&val}
-			// @ fold acc(proofs.NodeValuesInv(tmp.Elements))
+			prf.Elements = []*proofs.NodeValue{&val}
+			// @ fold proofs.NodeValuesInv(prf.Elements)
 		}
 		// @ fold acc(t.leaf.Inv(), p)
-		prf = &tmp
-		// @ fold acc(prf.Inv())
+		// @ fold prf.Inv()
 	} else {
 		var prf1, prf2 *proofs.PrefixProof
 		if t.left != nil {
@@ -600,9 +597,9 @@ func (t *Prefix) proofFromTree(depth uint8 /*@, ghost p perm @*/) (prf *proofs.P
 	return prf
 }
 
-// @ requires noPerm < p
+// @ requires  noPerm < p
 // @ preserves acc(t.Inv(), p)
-// @ ensures prf != nil ==> acc(prf.Inv())
+// @ ensures   prf != nil ==> prf.Inv()
 func (t *Prefix) ProofFromTree( /*@ ghost p perm @*/ ) (prf *proofs.PrefixProof) {
 	return t.proofFromTree(0 /*@, p @*/)
 }

--- a/pkg/trees/prefix.go
+++ b/pkg/trees/prefix.go
@@ -277,18 +277,12 @@ ghost
 requires  t != nil ==> acc(t.Inv(), _)
 ensures   0 <= r
 decreases acc(t.Inv(), _)
-pure func (t *Prefix) depth() (r int) {
+pure func (t *Prefix) depth() (r uint64) {
 	return t == nil ? 0 :
 		unfolding acc(t.Inv(), _) in
 			let lDepth := t.left == nil ? 0 : t.left.depth() in
 			let rDepth := t.right == nil ? 0 : t.right.depth() in
-			1 + max(lDepth, rDepth)
-}
-
-ghost
-decreases
-pure func max(a, b int) int {
-	return a >= b ? a : b
+			1 + utils.max(lDepth, rDepth)
 }
 
 ghost

--- a/pkg/trees/prefix.go
+++ b/pkg/trees/prefix.go
@@ -19,20 +19,22 @@ type prefixLeaf struct {
 }
 
 /*@
+// note that a `nil` Prefix satisfies the invariant.
 pred (l *prefixLeaf) Inv() {
-	acc(l) &&
-	(l.searchKey != nil ==> acc(l.searchKey)) &&
-	(l.commitment != nil ==> acc(l.commitment))
+	l != nil ==>
+		acc(l) &&
+		(l.searchKey != nil ==> acc(l.searchKey)) &&
+		(l.commitment != nil ==> acc(l.commitment))
 }
 @*/
 
-// @ requires noPerm < p
-// @ preserves pl != nil ==> acc(pl.Inv(), p)
-// @ ensures pl != nil ==> l != nil && acc(l.Inv())
+// @ requires  noPerm < p
+// @ preserves acc(pl.Inv(), p)
+// @ ensures   l.Inv()
+// @ ensures   pl != nil ==> l != nil
 func commitmentLeaf(pl *proofs.PrefixLeaf /*@, ghost p perm @*/) (l *prefixLeaf) {
+	// @ unfold acc(pl.Inv(), p)
 	if pl != nil {
-		// @ unfold acc(pl.Inv(), p)
-
 		// Spec: leaf.value = Hash(0x02 || vrf_output || commitment)
 		input := []byte{0x02}
 		input = append( /*@ p, @*/ input, pl.Vrf_output...)
@@ -43,17 +45,16 @@ func commitmentLeaf(pl *proofs.PrefixLeaf /*@, ghost p perm @*/) (l *prefixLeaf)
 		// The above assert is required so that gobra realizes the assert below.
 		// @ assert &c != pl.Commitment
 		// @ assert acc(&c)
-		l_ /*@@@*/ := prefixLeaf{
+		l = &prefixLeaf{
 			value: value,
 			// TODO: Could not use pl.Vrf_output[:], so opted for append.
 			// Folding pl.Inv() failed on using [:]
 			searchKey:  append( /*@ p, @*/ []byte{}, pl.Vrf_output...),
 			commitment: &c,
 		}
-		// @ fold acc(l_.Inv())
-		// @ fold acc(pl.Inv(), p)
-		l = &l_
 	}
+	// @ fold l.Inv()
+	// @ fold acc(pl.Inv(), p)
 	return
 }
 
@@ -64,11 +65,13 @@ type Prefix struct {
 }
 
 /*@
+// note that a `nil` Prefix satisfies the invariant.
 pred (t *Prefix) Inv() {
-	acc(t) &&
-	(t.leaf != nil ==> acc(t.leaf.Inv())) &&
-	(t.left != nil ==> acc(t.left.Inv())) &&
-	(t.right != nil ==> acc(t.right.Inv()))
+	t != nil ==>
+		acc(t) &&
+		(t.leaf != nil ==> acc(t.leaf.Inv())) &&
+		t.left.Inv() &&
+		t.right.Inv()
 }
 @*/
 
@@ -78,20 +81,22 @@ pred PrefixesInv(ts []*Prefix) {
 }
 @*/
 
-// @ ensures acc(t.Inv())
+// @ ensures t.Inv() && t != nil
 func mkTree() (t *Prefix) {
-	tmp_t /*@@@*/ := Prefix{}
-	// @ fold tmp_t.Inv()
-	return &tmp_t
+	t = &Prefix{}
+	// @ fold t.left.Inv()
+	// @ fold t.right.Inv()
+	// @ fold t.Inv()
+	return
 }
 
 // @ requires noPerm < p
-// @ preserves acc(t.Inv())
+// @ preserves t.Inv()
 // @ requires acc(path, p)
 // @ requires 0 <= depth
-// @ requires acc(leaf.Inv())
+// @ requires leaf.Inv()
 func (t *Prefix) insertAtChild(path []bool, depth int, leaf *prefixLeaf /*@, ghost p perm @*/) (err error) {
-	// @ unfold acc(t.Inv())
+	// @ unfold t.Inv()
 	if depth >= len(path) {
 		err = errors.New("path too short for tree depth")
 	} else if path[depth] {
@@ -105,44 +110,42 @@ func (t *Prefix) insertAtChild(path []bool, depth int, leaf *prefixLeaf /*@, gho
 		}
 		err = t.left.insert(path, depth+1, leaf /*@, p @*/)
 	}
-	// @ fold acc(t.Inv())
+	// @ fold t.Inv()
 	return
 }
 
 // @ requires noPerm < p
-// @ preserves acc(t.Inv())
+// @ preserves t.Inv()
 // @ requires acc(path, p)
 // @ requires 0 <= depth
-// @ requires acc(leaf.Inv())
+// @ requires leaf.Inv()
 func (t *Prefix) insert(path []bool, depth int, leaf *prefixLeaf /*@, ghost p perm @*/) (err error) {
-	if /*@ unfolding acc(t.Inv()) in @*/ t.leaf == nil && t.left == nil && t.right == nil {
-		// @ unfold acc(t.Inv())
+	// @ unfold t.Inv()
+	if t.leaf == nil && t.left == nil && t.right == nil {
 		t.leaf = leaf
-		// @ fold acc(t.Inv())
+		// @ fold t.Inv()
 	} else if len(path) <= depth {
 		// We arrived at the maximum depth; overwrite the respective leaf
-		// @ unfold acc(t.Inv())
 		t.leaf = leaf
 		// We assume that search keys are all of equal length. We enforce this
 		// property by setting the children to nil.
 		t.left = nil
 		t.right = nil
-		// @ fold acc(t.Inv())
+		// @ fold t.Inv()
 	} else {
 		// If there already is a leaf, "push it down" into the left or right
 		// subtree.
-		if /*@ unfolding acc(t.Inv()) in @*/ t.leaf != nil {
-			// @ unfold acc(t.Inv())
+		if t.leaf != nil {
 			recLeaf := t.leaf
 			t.leaf = nil
-			// @ fold acc(t.Inv())
+			// @ fold t.Inv()
 
-			if /*@ unfolding acc(recLeaf.Inv()) in @*/ recLeaf.searchKey == nil {
+			if /*@ unfolding recLeaf.Inv() in @*/ recLeaf.searchKey == nil {
 				err = errors.New("search key error at leaf")
 			} else {
-				// @ unfold acc(recLeaf.Inv())
+				// @ unfold recLeaf.Inv()
 				recSearchKey := utils.Bits(recLeaf.searchKey /*@, perm(1/2) @*/)
-				// @ fold acc(recLeaf.Inv())
+				// @ fold recLeaf.Inv()
 				err = t.insertAtChild(recSearchKey, depth, recLeaf /*@, perm(1/2) @*/)
 			}
 		}
@@ -154,8 +157,8 @@ func (t *Prefix) insert(path []bool, depth int, leaf *prefixLeaf /*@, ghost p pe
 	return
 }
 
-// @ preserves acc(t.Inv())
-// @ requires acc(leaf.Inv())
+// @ preserves t.Inv()
+// @ requires leaf.Inv()
 func (t *Prefix) Insert(leaf *prefixLeaf) (err error) {
 	// @ unfold acc(leaf.Inv(), perm(1/2))
 	searchKeyBits := utils.Bits(leaf.searchKey /*@, perm(1/2) @*/)
@@ -164,7 +167,7 @@ func (t *Prefix) Insert(leaf *prefixLeaf) (err error) {
 }
 
 // @ requires noPerm < p
-// @ preserves t != nil ==> acc(t.Inv(), p)
+// @ preserves acc(t.Inv(), p)
 func (t *Prefix) IsEmpty( /*@ ghost p perm @*/ ) (empty bool) {
 	if t == nil {
 		empty = true
@@ -182,34 +185,37 @@ func (t *Prefix) IsEmpty( /*@ ghost p perm @*/ ) (empty bool) {
 	return
 }
 
-// @ ensures acc(t.Inv())
+// @ ensures t.Inv()
 func nodeValueLeaf(nodeValue proofs.NodeValue) (t *Prefix) {
-	l /*@@@*/ := prefixLeaf{
+	l := &prefixLeaf{
 		value:      nodeValue,
 		searchKey:  nil,
 		commitment: nil,
 	}
 	// @ fold l.Inv()
-	tr /*@@@*/ := Prefix{
-		leaf:  &l,
+	t = &Prefix{
+		leaf:  l,
 		left:  nil,
 		right: nil,
 	}
-	// @ fold tr.Inv()
-	return &tr
+	// @ fold t.left.Inv()
+	// @ fold t.right.Inv()
+	// @ fold t.Inv()
+	return
 }
 
-// @ requires 0 <= depth && depth <= len(steps)
-// @ requires acc(t.Inv())
-// @ requires leaf != nil ==> acc(leaf.Inv())
+// @ requires  0 <= depth && depth <= len(steps)
+// @ requires  t.Inv() && leaf.Inv() && t != nil
 // @ preserves acc(steps)
-// @ ensures acc(t.Inv())
+// @ ensures   t.Inv()
 func (t *Prefix) setLeaf(steps []bool, depth int, leaf *prefixLeaf) {
 	// @ unfold t.Inv()
 	if depth == 0 {
 		t.leaf = leaf
 		t.left = nil
 		t.right = nil
+		// @ fold t.left.Inv()
+		// @ fold t.right.Inv()
 	} else {
 		stepsRec := steps[1:]
 		// @ assert forall i int :: {&stepsRec[i]} 0 <= i && i < len(stepsRec) ==> &stepsRec[i] == &steps[i+1]
@@ -228,12 +234,12 @@ func (t *Prefix) setLeaf(steps []bool, depth int, leaf *prefixLeaf) {
 	// @ fold t.Inv()
 }
 
-// @ requires noPerm < p
-// @ requires acc(proofs.NodeValuesInv(elements), p)
-// @ preserves acc(t.Inv())
+// @ requires  noPerm < p
+// @ requires  acc(proofs.NodeValuesInv(elements), p)
+// @ preserves t.Inv() && t != nil
 // @ ensures err == nil ==> acc(proofs.NodeValuesInv(es), p)
 func (t *Prefix) fill(elements []*proofs.NodeValue /*@, ghost p perm @*/) (es []*proofs.NodeValue, err error) {
-	// @ unfold acc(t.Inv())
+	// @ unfold t.Inv()
 	if t.leaf != nil {
 		es = elements
 	} else {
@@ -268,7 +274,7 @@ func (t *Prefix) fill(elements []*proofs.NodeValue /*@, ghost p perm @*/) (es []
 			}
 		}
 	}
-	// @ fold acc(t.Inv())
+	// @ fold t.Inv()
 	return
 }
 
@@ -278,42 +284,36 @@ func (t *Prefix) fill(elements []*proofs.NodeValue /*@, ghost p perm @*/) (es []
 
 /*@
 ghost
-requires t != nil ==> acc(t.Inv(), _)
-decreases t.Inv()
+requires  acc(t.Inv(), _)
+decreases acc(t.Inv(), _)
 pure func (t *Prefix) Included() (r seq[seq[bool]]) {
 	return (t == nil ?
 		// The empty leaf proves inclusion of no prefix
 		seq[seq[bool]]{} :
-		(unfolding t.Inv() in (t.leaf != nil ?
-			(unfolding t.leaf.Inv() in t.leaf.searchKey != nil ?
+		(unfolding acc(t.Inv(), _) in (t.leaf != nil ?
+			(unfolding acc(t.leaf.Inv(), _) in t.leaf.searchKey != nil ?
 				seq[seq[bool]]{ utils.Bits_Pure(t.leaf.searchKey) } :
 				seq[seq[bool]]{}) :
-			// TODO: For the termination measure to work, I must check that
-			// t.left/right are not nil. This is not ideal as the function already
-			// generalizes to t being nil, but I don't know how to express the
-			// termination measure accordingly.
-			(	let left := (t.left == nil ? seq[seq[bool]]{} : t.left.Included()) in
-				let right := (t.right == nil ? seq[seq[bool]]{} : t.right.Included()) in
-				left ++ right))))
+			(t.left.Included() ++ t.right.Included()))))
 }
 
 ghost
-requires t != nil ==> acc(t.Inv(), _)
-requires 0 <= depth
-decreases t.Inv()
+requires  acc(t.Inv(), _)
+requires  0 <= depth
+decreases acc(t.Inv(), _)
 pure func (t *Prefix) NotIncludedPrefixes(depth int) (r seq[seq[bool]]) {
 	return (t == nil ?
 		// The empty leaf proves non-inclusion of every suffix
 		seq[seq[bool]]{ seq[bool]{} } :
-		(unfolding t.Inv() in (t.leaf != nil ?
+		(unfolding acc(t.Inv(), _) in (t.leaf != nil ?
 			// A leaf proves the non-inclusion of no suffix
-			(unfolding t.leaf.Inv() in (t.leaf.searchKey != nil ?
+			(unfolding acc(t.leaf.Inv(), _) in (t.leaf.searchKey != nil ?
 				// No search key proves the non-inclusion of nothing; we are only given a hash
 				seq[seq[bool]]{} :
 				// A search key proves the non-inclusion of every intermediate infix with the last bit respectively flipped
 				utils.FlippedTailsPure(utils.Bits_Pure(t.leaf.searchKey), depth))) :
-			(	let left := utils.PrependAll(t.left == nil ? seq[seq[bool]]{ seq[bool]{} } : t.left.NotIncludedPrefixes(depth+1), false) in
-				let right := utils.PrependAll(t.right == nil ? seq[seq[bool]]{ seq[bool]{} } : t.right.NotIncludedPrefixes(depth+1), true) in
+			(	let left := utils.PrependAll(t.left.NotIncludedPrefixes(depth+1), false) in
+				let right := utils.PrependAll(t.right.NotIncludedPrefixes(depth+1), true) in
 				left ++ right))))
 }
 
@@ -324,8 +324,9 @@ pred NoPrefixMatches(prefixes seq[seq[bool]], values seq[seq[bool]]) {
 @*/
 
 // @ requires noPerm < p
-// @ preserves t != nil ==> acc(t.Inv(), p)
-// // @ requires low(t.Included())
+// @ requires acc(t.Inv(), p)
+// @ requires low(t.Included())
+// @ ensures  acc(t.Inv(), p)
 // // @ ensures low(r) && err == nil ==>
 // // @	NoPrefixMatches(rel(t, 0).NotIncludedPrefixes(0), rel(t, 1).Included()) &&
 // // @	NoPrefixMatches(rel(t, 1).NotIncludedPrefixes(0), rel(t, 0).Included())
@@ -359,44 +360,42 @@ func (t *Prefix) Value( /*@ ghost p perm @*/ ) (r [sha256.Size]byte, err error) 
 	return
 }
 
-// @ requires noPerm < p
+// @ requires  noPerm < p
 // @ preserves acc(searchKey, p)
-// @ requires acc(t.Inv(), p)
-// @ ensures acc(t.Inv(), p/2)
-// @ ensures l != nil ==> acc(l.Inv(), p/2)
+// @ requires  acc(t.Inv(), p)
+// @ ensures   acc(t.Inv(), p/2)
+// @ ensures   acc(l.Inv(), p/2)
 func (t *Prefix) getLeaf(searchKey []bool /*@, ghost p perm @*/) (l *prefixLeaf, ok bool) {
 	// @ unfold acc(t.Inv(), p)
-	if t.leaf != nil || len(searchKey) == 0 {
+	if t == nil {
+		ok = true
+		// @ fold acc(l.Inv(), p/2)
+	} else if t.leaf != nil || len(searchKey) == 0 {
 		l = t.leaf
 		ok = t.leaf != nil
+		/*@
+		if l == nil {
+			fold acc(l.Inv(), p/2)
+		}
+		@*/
 	} else {
 		rec := searchKey[1:]
 		// @ assert forall i int :: {&rec[i]} 0 <= i && i < len(rec) ==> &rec[i] == &searchKey[i+1]
 		if searchKey[0] {
-			if t.right == nil {
-				l = nil
-				ok = true
-			} else {
-				l, ok = t.right.getLeaf(rec /*@, p @*/)
-			}
+			l, ok = t.right.getLeaf(rec /*@, p @*/)
 		} else {
-			if t.left == nil {
-				l = nil
-				ok = true
-			} else {
-				l, ok = t.left.getLeaf(rec /*@, p @*/)
-			}
+			l, ok = t.left.getLeaf(rec /*@, p @*/)
 		}
 	}
 	// @ fold acc(t.Inv(), p/2)
 	return
 }
 
-// @ requires noPerm < p
-// @ requires acc(t.Inv(), p)
+// @ requires  noPerm < p
+// @ requires  acc(t.Inv(), p)
 // @ preserves acc(searchKey, p)
-// @ ensures acc(t.Inv(), p/2)
-// @ ensures r != nil ==> acc(r, p/2)
+// @ ensures   acc(t.Inv(), p/2)
+// @ ensures   r != nil ==> acc(r, p/2)
 func (t *Prefix) Search(searchKey []byte /*@, ghost p perm @*/) (r *[sha256.Size]byte, ok bool) {
 	// TODO: Cannot return r == nil && ok
 	if leaf, leafOk := t.getLeaf(utils.Bits(searchKey /*@, p @*/) /*@, p @*/); !leafOk {
@@ -421,12 +420,14 @@ func (t *Prefix) Search(searchKey []byte /*@, ghost p perm @*/) (r *[sha256.Size
 
 // @ requires noPerm < p
 // @ requires acc(prf.Inv(), p)
-// @ ensures err == nil ==> acc(tree.Inv())
+// @ ensures  err == nil ==> tree.Inv()
 func MkPrefix(prf *proofs.PrefixProof /*@, ghost p perm @*/) (tree *Prefix, err error) {
 	tree = &Prefix{}
-	// @ fold acc(tree.Inv())
+	// @ fold tree.left.Inv()
+	// @ fold tree.right.Inv()
+	// @ fold tree.Inv()
 
-	// @ invariant acc(tree.Inv())
+	// @ invariant tree.Inv()
 	// @ invariant acc(prf.Inv(), p)
 	// @ invariant 0 <= i && i <= len(unfolding acc(prf.Inv(), p) in prf.Results)
 	for i := 0; i < len( /*@ unfolding acc(prf.Inv(), p) in @*/ prf.Results); i++ {


### PR DESCRIPTION
Given that the implementation seems to deal with `nil` Prefix and prefixLeaf, I thought that we might want to capture this in the respective predicate definition.
I'd be curious about your thoughts on this and would make this mostly dependent on the fact whether from a package's client perspective a `nil` Prefix ever makes sense or not